### PR TITLE
Additional group hierarchy transaction fixes

### DIFF
--- a/pkg/api/v1alpha1/group_hierarchies.go
+++ b/pkg/api/v1alpha1/group_hierarchies.go
@@ -94,24 +94,12 @@ func (r *Router) addMemberGroup(c *gin.Context) {
 	).One(c.Request.Context(), tx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			msg := "group not found: " + err.Error()
-
-			if err := tx.Rollback(); err != nil {
-				msg += "error rolling back transaction: " + err.Error()
-			}
-
-			sendError(c, http.StatusNotFound, msg)
+			rollbackWithError(c, tx, err, http.StatusNotFound, "group not found")
 
 			return
 		}
 
-		msg := "error getting group: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusInternalServerError, msg)
+		rollbackWithError(c, tx, err, http.StatusInternalServerError, "error getting group")
 
 		return
 	}
@@ -119,24 +107,12 @@ func (r *Router) addMemberGroup(c *gin.Context) {
 	memberGroup, err := models.FindGroup(c.Request.Context(), tx, req.MemberGroupID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			msg := "group not found: " + err.Error()
-
-			if err := tx.Rollback(); err != nil {
-				msg += "error rolling back transaction: " + err.Error()
-			}
-
-			sendError(c, http.StatusNotFound, msg)
+			rollbackWithError(c, tx, err, http.StatusNotFound, "group not found")
 
 			return
 		}
 
-		msg := "error getting group: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusInternalServerError, msg)
+		rollbackWithError(c, tx, err, http.StatusInternalServerError, "error getting group")
 
 		return
 	}
@@ -146,38 +122,20 @@ func (r *Router) addMemberGroup(c *gin.Context) {
 		qm.And("member_group_id = ?", memberGroup.ID),
 	).Exists(c.Request.Context(), tx)
 	if err != nil {
-		msg := "error checking group hierarchy exists: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusInternalServerError, msg)
+		rollbackWithError(c, tx, err, http.StatusInternalServerError, "error checking group hierarchy exists")
 
 		return
 	}
 
 	if exists {
-		msg := "group is already a member: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusConflict, msg)
+		rollbackWithError(c, tx, err, http.StatusConflict, "group is already a member")
 
 		return
 	}
 
 	createsCycle, err := dbtools.HierarchyWouldCreateCycle(c, tx, parentGroup.ID, memberGroup.ID)
 	if err != nil {
-		msg := "could not determine whether the desired hierarchy creates a cycle: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusInternalServerError, msg)
+		rollbackWithError(c, tx, err, http.StatusInternalServerError, "could not determine whether the desired hierarchy creates a cycle")
 
 		return
 	}
@@ -202,75 +160,39 @@ func (r *Router) addMemberGroup(c *gin.Context) {
 
 	membershipsBefore, err := dbtools.GetAllGroupMemberships(c, tx, false)
 	if err != nil {
-		msg := "failed to compute new effective memberships: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "failed to compute new effective memberships")
 
 		return
 	}
 
 	if err := groupHierarchy.Insert(c.Request.Context(), tx, boil.Infer()); err != nil {
-		msg := "failed to update group hierarchy: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "failed to update group hierarchy")
 
 		return
 	}
 
 	event, err := dbtools.AuditGroupHierarchyCreated(c.Request.Context(), tx, getCtxAuditID(c), getCtxUser(c), groupHierarchy)
 	if err != nil {
-		msg := "error creating groups hierarchy (audit): " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "error creating groups hierarchy (audit)")
 
 		return
 	}
 
 	if err := updateContextWithAuditEventData(c, event); err != nil {
-		msg := "error creating groups hierarchy (audit): " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "error creating groups hierarchy (audit)")
 
 		return
 	}
 
 	membershipsAfter, err := dbtools.GetAllGroupMemberships(c, tx, false)
 	if err != nil {
-		msg := "failed to compute new effective memberships: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "failed to compute new effective memberships")
 
 		return
 	}
 
 	if err := tx.Commit(); err != nil {
-		msg := "error committing groups hierarchy, rolling back: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg = msg + "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "error committing groups hierarchy, rolling back")
 
 		return
 	}
@@ -331,24 +253,12 @@ func (r *Router) updateMemberGroup(c *gin.Context) {
 	).One(c.Request.Context(), tx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			msg := "hierarchy not found: " + err.Error()
-
-			if err := tx.Rollback(); err != nil {
-				msg += "error rolling back transaction: " + err.Error()
-			}
-
-			sendError(c, http.StatusBadRequest, msg)
+			rollbackWithError(c, tx, err, http.StatusBadRequest, "hierarchy not found")
 
 			return
 		}
 
-		msg := "error getting hierarchy: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "error getting hierarchy")
 
 		return
 	}
@@ -356,13 +266,7 @@ func (r *Router) updateMemberGroup(c *gin.Context) {
 	hierarchy.ExpiresAt = req.ExpiresAt
 
 	if _, err := hierarchy.Update(c.Request.Context(), tx, boil.Infer()); err != nil {
-		msg := "failed to update hierarchy: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "failed to update hierarchy")
 
 		return
 	}
@@ -371,37 +275,19 @@ func (r *Router) updateMemberGroup(c *gin.Context) {
 
 	event, err = dbtools.AuditGroupHierarchyUpdated(c.Request.Context(), tx, getCtxAuditID(c), getCtxUser(c), hierarchy)
 	if err != nil {
-		msg := "error creating hierarchy (audit): " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "error creating hierarchy (audit)")
 
 		return
 	}
 
 	if err := updateContextWithAuditEventData(c, event); err != nil {
-		msg := "error updating hierarchy (audit): " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "error creating hierarchy (audit)")
 
 		return
 	}
 
 	if err := tx.Commit(); err != nil {
-		msg := "error committing hierarchy update, rolling back: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg = msg + "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "error committing hierarchy update, rolling back")
 
 		return
 	}
@@ -437,99 +323,51 @@ func (r *Router) removeMemberGroup(c *gin.Context) {
 	).One(c.Request.Context(), tx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			msg := "hierarchy not found: " + err.Error()
-
-			if err := tx.Rollback(); err != nil {
-				msg = msg + "error rolling back transaction: " + err.Error()
-			}
-
-			sendError(c, http.StatusBadRequest, msg)
+			rollbackWithError(c, tx, err, http.StatusNotFound, "hierarchy not found")
 
 			return
 		}
 
-		msg := "error getting hierarchy: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg = msg + "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "error getting hierarchy")
 
 		return
 	}
 
 	membershipsBefore, err := dbtools.GetAllGroupMemberships(c, tx, false)
 	if err != nil {
-		msg := "failed to compute new effective memberships: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "failed to compute new effective memberships")
 
 		return
 	}
 
 	if _, err := hierarchy.Delete(c.Request.Context(), tx); err != nil {
-		msg := "error removing hierarchy: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "error removing hierarchy")
 
 		return
 	}
 
 	event, err := dbtools.AuditGroupHierarchyDeleted(c.Request.Context(), tx, getCtxAuditID(c), getCtxUser(c), hierarchy)
 	if err != nil {
-		msg := "error deleting groups hierarchy (audit): " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "error deleting groups hierarchy (audit)")
 
 		return
 	}
 
 	if err := updateContextWithAuditEventData(c, event); err != nil {
-		msg := "error deleting group hierarchy (audit): " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "error deleting groups hierarchy (audit)")
 
 		return
 	}
 
 	membershipsAfter, err := dbtools.GetAllGroupMemberships(c, tx, false)
 	if err != nil {
-		msg := "failed to compute new effective memberships: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg += "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "failed to compute new effective memberships")
 
 		return
 	}
 
 	if err := tx.Commit(); err != nil {
-		msg := "error committing hierarchy delete, rolling back: " + err.Error()
-
-		if err := tx.Rollback(); err != nil {
-			msg = msg + "error rolling back transaction: " + err.Error()
-		}
-
-		sendError(c, http.StatusBadRequest, msg)
+		rollbackWithError(c, tx, err, http.StatusBadRequest, "error committing hierarchy delete, rolling back")
 
 		return
 	}
@@ -591,4 +429,14 @@ func (r *Router) getGroupHierarchiesAll(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, hierarchiesResponse)
+}
+
+func rollbackWithError(c *gin.Context, tx *sql.Tx, err error, code int, initialMsg string) {
+	msg := initialMsg + err.Error()
+
+	if err := tx.Rollback(); err != nil {
+		msg = msg + "error rolling back transaction: " + err.Error()
+	}
+
+	sendError(c, code, msg)
 }

--- a/pkg/api/v1alpha1/group_hierarchies.go
+++ b/pkg/api/v1alpha1/group_hierarchies.go
@@ -101,6 +101,7 @@ func (r *Router) addMemberGroup(c *gin.Context) {
 			}
 
 			sendError(c, http.StatusNotFound, msg)
+
 			return
 		}
 
@@ -125,6 +126,7 @@ func (r *Router) addMemberGroup(c *gin.Context) {
 			}
 
 			sendError(c, http.StatusNotFound, msg)
+
 			return
 		}
 
@@ -151,6 +153,7 @@ func (r *Router) addMemberGroup(c *gin.Context) {
 		}
 
 		sendError(c, http.StatusInternalServerError, msg)
+
 		return
 	}
 
@@ -162,6 +165,7 @@ func (r *Router) addMemberGroup(c *gin.Context) {
 		}
 
 		sendError(c, http.StatusConflict, msg)
+
 		return
 	}
 
@@ -334,6 +338,7 @@ func (r *Router) updateMemberGroup(c *gin.Context) {
 			}
 
 			sendError(c, http.StatusBadRequest, msg)
+
 			return
 		}
 
@@ -344,6 +349,7 @@ func (r *Router) updateMemberGroup(c *gin.Context) {
 		}
 
 		sendError(c, http.StatusBadRequest, msg)
+
 		return
 	}
 
@@ -438,6 +444,7 @@ func (r *Router) removeMemberGroup(c *gin.Context) {
 			}
 
 			sendError(c, http.StatusBadRequest, msg)
+
 			return
 		}
 

--- a/pkg/api/v1alpha1/group_hierarchies.go
+++ b/pkg/api/v1alpha1/group_hierarchies.go
@@ -170,7 +170,7 @@ func (r *Router) addMemberGroup(c *gin.Context) {
 		return
 	}
 
-	if err := groupHierarchy.Insert(c.Request.Context(), r.DB, boil.Infer()); err != nil {
+	if err := groupHierarchy.Insert(c.Request.Context(), tx, boil.Infer()); err != nil {
 		msg := "failed to update group hierarchy: " + err.Error()
 
 		if err := tx.Rollback(); err != nil {
@@ -299,7 +299,7 @@ func (r *Router) updateMemberGroup(c *gin.Context) {
 		return
 	}
 
-	if _, err := hierarchy.Update(c.Request.Context(), r.DB, boil.Infer()); err != nil {
+	if _, err := hierarchy.Update(c.Request.Context(), tx, boil.Infer()); err != nil {
 		msg := "failed to update hierarchy: " + err.Error()
 
 		if err := tx.Rollback(); err != nil {
@@ -403,7 +403,7 @@ func (r *Router) removeMemberGroup(c *gin.Context) {
 		return
 	}
 
-	if _, err := hierarchy.Delete(c.Request.Context(), r.DB); err != nil {
+	if _, err := hierarchy.Delete(c.Request.Context(), tx); err != nil {
 		msg := "error removing hierarchy: " + err.Error()
 
 		if err := tx.Rollback(); err != nil {


### PR DESCRIPTION
- Calculation of added/deleted group members was not properly bound only to the transaction it was running in
- Moved cycle detection step inside the transaction, to take advantage of serializable transactions