### PR TITLE
admin_expires_at for indirect members is always null

### DIFF
--- a/internal/dbtools/membership_enumeration.go
+++ b/internal/dbtools/membership_enumeration.go
@@ -51,7 +51,7 @@ const (
 			b.parent_group_id,
 			a.user_id,
 			b.expires_at,
-			b.admin_expires_at,
+			NULL as admin_expires_at,
 			FALSE AS is_admin,
 			FALSE AS direct
 		FROM


### PR DESCRIPTION
Small bug - admin expiration is always null (concept of admin doesn't exist) on indirect membership and should not be treated as a column to lookup here