### PR TITLE
[Extend Governor APIs] Extension Resource Definitions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nats-io/nats.go v1.28.0
 	github.com/pressly/goose/v3 v3.14.0
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -584,6 +584,8 @@ github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThC
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.6.0/go.mod h1:U8+INwJo3nBv1m6A/8OBXAq7Jnpspk5AxSgDyEQcea8=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=

--- a/internal/dbtools/hooks.go
+++ b/internal/dbtools/hooks.go
@@ -1069,3 +1069,60 @@ func AuditExtensionDeleted(ctx context.Context, exec boil.ContextExecutor, pID s
 
 	return &event, event.Insert(ctx, exec, boil.Infer())
 }
+
+// AuditExtensionResourceDefinitionCreated inserts an event representing a extension being created
+func AuditExtensionResourceDefinitionCreated(ctx context.Context, exec boil.ContextExecutor, pID string, actor *models.User, erd *models.ExtensionResourceDefinition) (*models.AuditEvent, error) {
+	// TODO non-user API actors don't exist in the governor database,
+	// we need to figure out how to handle that relationship in the audit table
+	var actorID null.String
+	if actor != nil {
+		actorID = null.StringFrom(actor.ID)
+	}
+
+	event := models.AuditEvent{
+		ParentID:  null.StringFrom(pID),
+		ActorID:   actorID,
+		Action:    "extension.erd.created",
+		Changeset: calculateChangeset(&models.ExtensionResourceDefinition{}, erd),
+	}
+
+	return &event, event.Insert(ctx, exec, boil.Infer())
+}
+
+// AuditExtensionResourceDefinitionUpdated inserts an event representing a extension being created
+func AuditExtensionResourceDefinitionUpdated(ctx context.Context, exec boil.ContextExecutor, pID string, actor *models.User, o, a *models.ExtensionResourceDefinition) (*models.AuditEvent, error) {
+	// TODO non-user API actors don't exist in the governor database,
+	// we need to figure out how to handle that relationship in the audit table
+	var actorID null.String
+	if actor != nil {
+		actorID = null.StringFrom(actor.ID)
+	}
+
+	event := models.AuditEvent{
+		ParentID:  null.StringFrom(pID),
+		ActorID:   actorID,
+		Action:    "extension.erd.updated",
+		Changeset: calculateChangeset(o, a),
+	}
+
+	return &event, event.Insert(ctx, exec, boil.Infer())
+}
+
+// AuditExtensionResourceDefinitionDeleted inserts an event representing a extension being created
+func AuditExtensionResourceDefinitionDeleted(ctx context.Context, exec boil.ContextExecutor, pID string, actor *models.User, erd *models.ExtensionResourceDefinition) (*models.AuditEvent, error) {
+	// TODO non-user API actors don't exist in the governor database,
+	// we need to figure out how to handle that relationship in the audit table
+	var actorID null.String
+	if actor != nil {
+		actorID = null.StringFrom(actor.ID)
+	}
+
+	event := models.AuditEvent{
+		ParentID:  null.StringFrom(pID),
+		ActorID:   actorID,
+		Action:    "extension.erd.deleted",
+		Changeset: calculateChangeset(erd, &models.ExtensionResourceDefinition{}),
+	}
+
+	return &event, event.Insert(ctx, exec, boil.Infer())
+}

--- a/pkg/api/v1alpha1/extension_resource_definitions.go
+++ b/pkg/api/v1alpha1/extension_resource_definitions.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -45,6 +46,13 @@ type ExtensionResourceDefinitionReq struct {
 	Scope        ExtensionResourceDefinitionScope `json:"scope"`
 	Schema       json.RawMessage                  `json:"schema"`
 	Enabled      *bool                            `json:"enabled"`
+}
+
+func isValidSlug(s string) bool {
+	// This regex ensures the slug is lowercase, uses hyphens to separate words,
+	// does not start or end with a hyphen, and contains only alphanumeric characters or hyphens.
+	pattern := regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+	return pattern.MatchString(s)
 }
 
 func findERD(
@@ -163,6 +171,11 @@ func (r *Router) createExtensionResourceDefinition(c *gin.Context) {
 
 	if req.SlugSingular == "" || req.SlugPlural == "" {
 		sendError(c, http.StatusBadRequest, "ERD slugs are required")
+		return
+	}
+
+	if !isValidSlug(req.SlugSingular) || !isValidSlug(req.SlugPlural) {
+		sendError(c, http.StatusBadRequest, "one or both of ERD slugs are invalid")
 		return
 	}
 

--- a/pkg/api/v1alpha1/extension_resource_definitions.go
+++ b/pkg/api/v1alpha1/extension_resource_definitions.go
@@ -1,0 +1,617 @@
+package v1alpha1
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/metal-toolbox/auditevent/ginaudit"
+	"github.com/metal-toolbox/governor-api/internal/dbtools"
+	"github.com/metal-toolbox/governor-api/internal/models"
+	events "github.com/metal-toolbox/governor-api/pkg/events/v1alpha1"
+	"github.com/volatiletech/sqlboiler/v4/boil"
+	"github.com/volatiletech/sqlboiler/v4/queries/qm"
+
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+// ExtensionResourceDefinition is the extension resource definition response
+type ExtensionResourceDefinition struct {
+	*models.ExtensionResourceDefinition
+}
+
+// ExtensionResourceDefinitionScope is an enum type for scopes in an ERD
+type ExtensionResourceDefinitionScope string
+
+const (
+	// ExtensionResourceDefinitionScopeUser represents the `user` scope
+	ExtensionResourceDefinitionScopeUser ExtensionResourceDefinitionScope = "user"
+	// ExtensionResourceDefinitionScopeSys represents the `system` scope
+	ExtensionResourceDefinitionScopeSys = "system"
+)
+
+// ExtensionResourceDefinitionReq is a request to create an extension resource definition
+type ExtensionResourceDefinitionReq struct {
+	Name         string                           `json:"name"`
+	Description  string                           `json:"description"`
+	SlugSingular string                           `json:"slug_singular"`
+	SlugPlural   string                           `json:"slug_plural"`
+	Version      string                           `json:"version"`
+	Scope        ExtensionResourceDefinitionScope `json:"scope"`
+	Schema       json.RawMessage                  `json:"schema"`
+	Enabled      *bool                            `json:"enabled"`
+}
+
+func findERD(
+	ctx context.Context, exec boil.ContextExecutor,
+	extensionID, erdIDOrSlug, erdVersion string, deleted bool,
+) (extension *models.Extension, erd *models.ExtensionResourceDefinition, err error) {
+	// fetch extension
+	var extensionQM qm.QueryMod
+	if _, err := uuid.Parse(extensionID); err != nil {
+		extensionQM = qm.Where("slug = ?", extensionID)
+	} else {
+		extensionQM = qm.Where("id = ?", extensionID)
+	}
+
+	// fetch ERD
+	queryMods := []qm.QueryMod{}
+
+	// use slug if uuid is invalid
+	if _, err = uuid.Parse(erdIDOrSlug); err != nil {
+		if deleted {
+			return nil, nil, ErrGetDeleteResourcedWithSlug
+		}
+
+		if erdVersion == "" {
+			return nil, nil, err
+		}
+
+		queryMods = append(queryMods, qm.Where("slug_singular = ?", erdIDOrSlug))
+		queryMods = append(queryMods, qm.Where("version = ?", erdVersion))
+	} else {
+		queryMods = append(queryMods, qm.Where("id = ?", erdIDOrSlug))
+	}
+
+	if deleted {
+		queryMods = append(queryMods, qm.WithDeleted())
+	}
+
+	extension, err = models.Extensions(
+		extensionQM,
+		qm.Load(
+			models.ExtensionRels.ExtensionResourceDefinitions,
+			queryMods...,
+		),
+	).One(ctx, exec)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil, ErrExtensionNotFound
+		}
+
+		return
+	}
+
+	if len(extension.R.ExtensionResourceDefinitions) < 1 {
+		return nil, nil, ErrERDNotFound
+	}
+
+	erd = extension.R.ExtensionResourceDefinitions[0]
+
+	return
+}
+
+// listExtensionResourceDefinitions lists extension resource definitions as JSON
+func (r *Router) listExtensionResourceDefinitions(c *gin.Context) {
+	extensionID := c.Param("eid")
+	erdQMs := []qm.QueryMod{
+		qm.OrderBy("name"),
+	}
+
+	deleted := false
+	if _, deleted = c.GetQuery("deleted"); deleted {
+		erdQMs = append(erdQMs, qm.WithDeleted())
+	}
+
+	var extensionQM qm.QueryMod
+
+	if _, err := uuid.Parse(extensionID); err != nil {
+		extensionQM = qm.Where("slug = ?", extensionID)
+	} else {
+		extensionQM = qm.Where("id = ?", extensionID)
+	}
+
+	extension, err := models.Extensions(
+		extensionQM, qm.Load(
+			models.ExtensionRels.ExtensionResourceDefinitions,
+			erdQMs...,
+		),
+	).One(c.Request.Context(), r.DB)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			sendError(c, http.StatusNotFound, "extension not found: "+err.Error())
+			return
+		}
+
+		sendError(c, http.StatusInternalServerError, "error getting ERD"+err.Error())
+
+		return
+	}
+
+	c.JSON(http.StatusOK, extension.R.ExtensionResourceDefinitions)
+}
+
+// createExtensionResourceDefinition creates an extension resource definition in DB
+func (r *Router) createExtensionResourceDefinition(c *gin.Context) {
+	extensionID := c.Param("eid")
+
+	req := &ExtensionResourceDefinitionReq{}
+	if err := c.BindJSON(req); err != nil {
+		sendError(c, http.StatusBadRequest, "unable to bind request: "+err.Error())
+		return
+	}
+
+	if req.Name == "" {
+		sendError(c, http.StatusBadRequest, "ERD name is required")
+		return
+	}
+
+	if req.SlugSingular == "" || req.SlugPlural == "" {
+		sendError(c, http.StatusBadRequest, "ERD slugs are required")
+		return
+	}
+
+	if req.Version == "" {
+		sendError(c, http.StatusBadRequest, "ERD version is required")
+		return
+	}
+
+	if req.Enabled == nil {
+		sendError(c, http.StatusBadRequest, "ERD enabled is required")
+		return
+	}
+
+	if req.Scope == "" {
+		sendError(c, http.StatusBadRequest, "ERD scope is required")
+		return
+	}
+
+	if req.Scope != ExtensionResourceDefinitionScopeUser && req.Scope != ExtensionResourceDefinitionScopeSys {
+		sendError(c, http.StatusBadRequest, `invalid ERD scope, "system" or "user"`)
+		return
+	}
+
+	if string(req.Schema) == "" {
+		sendError(c, http.StatusBadRequest, "ERD schema is required")
+		return
+	}
+
+	// user may choose to upload the schema as an escaped JSON string, here uses
+	// a string unmarshal to "un-escape" the JSON string.
+	var schema string
+	if err := json.Unmarshal(req.Schema, &schema); err != nil {
+		// if the user upload the schema as an object, simply convert the bytes to
+		// string should suffice
+		schema = string(req.Schema)
+	}
+
+	if _, err := jsonschema.CompileString("https://governor/s.json", schema); err != nil {
+		sendError(c, http.StatusBadRequest, "ERD schema is not valid: "+err.Error())
+		return
+	}
+
+	erd := &models.ExtensionResourceDefinition{
+		Name:         req.Name,
+		SlugSingular: req.SlugSingular,
+		SlugPlural:   req.SlugPlural,
+		Version:      req.Version,
+		Description:  req.Description,
+		Scope:        string(req.Scope),
+		Schema:       []byte(schema),
+		Enabled:      *req.Enabled,
+	}
+
+	var extensionQM qm.QueryMod
+
+	if _, err := uuid.Parse(extensionID); err != nil {
+		extensionQM = qm.Where("slug = ?", extensionID)
+	} else {
+		extensionQM = qm.Where("id = ?", extensionID)
+	}
+
+	extension, err := models.Extensions(extensionQM).One(c.Request.Context(), r.DB)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			sendError(c, http.StatusNotFound, "extension not found: "+err.Error())
+			return
+		}
+
+		sendError(c, http.StatusInternalServerError, "error getting ERD"+err.Error())
+
+		return
+	}
+
+	tx, err := r.DB.BeginTx(c.Request.Context(), nil)
+	if err != nil {
+		sendError(c, http.StatusBadRequest, "error starting ERD create transaction: "+err.Error())
+		return
+	}
+
+	if err := extension.AddExtensionResourceDefinitions(c.Request.Context(), tx, true, erd); err != nil {
+		msg := fmt.Sprintf("error creating ERD: %s", err.Error())
+
+		if err := tx.Rollback(); err != nil {
+			msg += fmt.Sprintf("error rolling back transaction: %s", err.Error())
+		}
+
+		sendError(c, http.StatusBadRequest, msg)
+
+		return
+	}
+
+	event, err := dbtools.AuditExtensionResourceDefinitionCreated(
+		c.Request.Context(),
+		tx,
+		getCtxAuditID(c),
+		getCtxUser(c),
+		erd,
+	)
+	if err != nil {
+		msg := fmt.Sprintf("error creating ERD (audit): %s", err.Error())
+
+		if err := tx.Rollback(); err != nil {
+			msg += fmt.Sprintf("error rolling back transaction: %s", err.Error())
+		}
+
+		sendError(c, http.StatusBadRequest, msg)
+
+		return
+	}
+
+	if err := updateContextWithAuditEventData(c, event); err != nil {
+		msg := fmt.Sprintf("error creating ERD: %s", err.Error())
+
+		if err := tx.Rollback(); err != nil {
+			msg += fmt.Sprintf("error rolling back transaction: %s", err.Error())
+		}
+
+		sendError(c, http.StatusBadRequest, msg)
+
+		return
+	}
+
+	if err := tx.Commit(); err != nil {
+		msg := fmt.Sprintf("error committing ERD create: %s", err.Error())
+
+		if err := tx.Rollback(); err != nil {
+			msg += fmt.Sprintf("error rolling back transaction: %s", err.Error())
+		}
+
+		sendError(c, http.StatusBadRequest, msg)
+
+		return
+	}
+
+	err = r.EventBus.Publish(
+		c.Request.Context(),
+		events.GovernorExtensionResourceDefinitionsEventSubject,
+		&events.Event{
+			Version:                       events.Version,
+			Action:                        events.GovernorEventCreate,
+			AuditID:                       c.GetString(ginaudit.AuditIDContextKey),
+			ActorID:                       getCtxActorID(c),
+			ExtensionID:                   extension.ID,
+			ExtensionResourceDefinitionID: erd.ID,
+		},
+	)
+	if err != nil {
+		sendError(
+			c,
+			http.StatusBadRequest,
+			fmt.Sprintf(
+				"failed to publish extension create event: %s\n%s",
+				err.Error(),
+				"downstream changes may be delayed",
+			),
+		)
+
+		return
+	}
+
+	c.JSON(http.StatusAccepted, erd)
+}
+
+// getExtensionResourceDefinition fetch a extension from DB with given id
+func (r *Router) getExtensionResourceDefinition(c *gin.Context) {
+	extensionID := c.Param("eid")
+	erdIDOrSlug := c.Param("erd-id-slug")
+	erdVersion := c.Param("erd-version")
+	_, deleted := c.GetQuery("deleted")
+
+	_, erd, err := findERD(
+		c.Request.Context(), r.DB,
+		extensionID, erdIDOrSlug, erdVersion, deleted,
+	)
+	if err != nil {
+		if errors.Is(err, ErrExtensionNotFound) || errors.Is(err, ErrERDNotFound) {
+			sendError(c, http.StatusNotFound, err.Error())
+			return
+		}
+
+		sendError(c, http.StatusBadRequest, err.Error())
+
+		return
+	}
+
+	c.JSON(http.StatusOK, erd)
+}
+
+// deleteExtensionResourceDefinition marks a extension deleted
+func (r *Router) deleteExtensionResourceDefinition(c *gin.Context) {
+	extensionID := c.Param("eid")
+	erdIDOrSlug := c.Param("erd-id-slug")
+	erdVersion := c.Param("erd-version")
+	_, deleted := c.GetQuery("deleted")
+
+	extension, erd, err := findERD(
+		c.Request.Context(), r.DB,
+		extensionID, erdIDOrSlug, erdVersion, deleted,
+	)
+	if err != nil {
+		if errors.Is(err, ErrExtensionNotFound) || errors.Is(err, ErrERDNotFound) {
+			sendError(c, http.StatusNotFound, err.Error())
+			return
+		}
+
+		sendError(c, http.StatusBadRequest, err.Error())
+
+		return
+	}
+
+	tx, err := r.DB.BeginTx(c.Request.Context(), nil)
+	if err != nil {
+		sendError(c, http.StatusBadRequest, "error starting delete transaction: "+err.Error())
+		return
+	}
+
+	if _, err := erd.Delete(c.Request.Context(), tx, false); err != nil {
+		msg := fmt.Sprintf("error deleting ERD: %s. rolling back\n", err.Error())
+
+		if err := tx.Rollback(); err != nil {
+			msg += fmt.Sprintf("error rolling back transaction: %s", err.Error())
+		}
+
+		sendError(c, http.StatusBadRequest, msg)
+
+		return
+	}
+
+	event, err := dbtools.AuditExtensionResourceDefinitionDeleted(
+		c.Request.Context(),
+		tx,
+		getCtxAuditID(c),
+		getCtxUser(c),
+		erd,
+	)
+	if err != nil {
+		msg := fmt.Sprintf("error deleting ERD (audit): %s", err.Error())
+
+		if err := tx.Rollback(); err != nil {
+			msg += fmt.Sprintf("error rolling back transaction: %s", err.Error())
+		}
+
+		sendError(c, http.StatusBadRequest, msg)
+
+		return
+	}
+
+	if err := updateContextWithAuditEventData(c, event); err != nil {
+		msg := fmt.Sprintf("error deleting ERD: %s", err.Error())
+
+		if err := tx.Rollback(); err != nil {
+			msg += fmt.Sprintf("error rolling back transaction: %s", err.Error())
+		}
+
+		sendError(c, http.StatusBadRequest, msg)
+
+		return
+	}
+
+	if err := tx.Commit(); err != nil {
+		msg := fmt.Sprintf("error committing ERD delete: %s", err.Error())
+
+		if err := tx.Rollback(); err != nil {
+			msg += fmt.Sprintf("error rolling back transaction: %s", err.Error())
+		}
+
+		sendError(c, http.StatusBadRequest, msg)
+
+		return
+	}
+
+	err = r.EventBus.Publish(
+		c.Request.Context(),
+		events.GovernorExtensionResourceDefinitionsEventSubject,
+		&events.Event{
+			Version:                       events.Version,
+			Action:                        events.GovernorEventDelete,
+			AuditID:                       c.GetString(ginaudit.AuditIDContextKey),
+			ActorID:                       getCtxActorID(c),
+			ExtensionID:                   extension.ID,
+			ExtensionResourceDefinitionID: erd.ID,
+		},
+	)
+	if err != nil {
+		sendError(
+			c,
+			http.StatusBadRequest,
+			fmt.Sprintf(
+				"failed to publish extension delete event: %s\n%s",
+				err.Error(),
+				"downstream changes may be delayed",
+			),
+		)
+
+		return
+	}
+
+	c.JSON(http.StatusAccepted, extension)
+}
+
+// updateExtensionResourceDefinition updates a extension in DB
+func (r *Router) updateExtensionResourceDefinition(c *gin.Context) {
+	extensionID := c.Param("eid")
+	erdIDOrSlug := c.Param("erd-id-slug")
+	erdVersion := c.Param("erd-version")
+	_, deleted := c.GetQuery("deleted")
+
+	extension, erd, err := findERD(
+		c.Request.Context(), r.DB,
+		extensionID, erdIDOrSlug, erdVersion, deleted,
+	)
+	if err != nil {
+		if errors.Is(err, ErrExtensionNotFound) || errors.Is(err, ErrERDNotFound) {
+			sendError(c, http.StatusNotFound, err.Error())
+			return
+		}
+
+		sendError(c, http.StatusBadRequest, err.Error())
+
+		return
+	}
+
+	req := &ExtensionResourceDefinitionReq{}
+	if err := c.BindJSON(req); err != nil {
+		sendError(c, http.StatusBadRequest, "unable to bind request: "+err.Error())
+		return
+	}
+
+	if (req.SlugPlural != "" && req.SlugPlural != erd.SlugPlural) || (req.SlugSingular != "" && req.SlugSingular != erd.SlugSingular) {
+		sendError(c, http.StatusBadRequest, "ERD slugs are immutable")
+		return
+	}
+
+	if req.Scope != "" && req.Scope != ExtensionResourceDefinitionScope(erd.Scope) {
+		sendError(c, http.StatusBadRequest, "ERD scope is immutable")
+		return
+	}
+
+	if req.Version != "" && req.Version != erd.Version {
+		sendError(c, http.StatusBadRequest, "ERD version is immutable")
+		return
+	}
+
+	if string(req.Schema) != "" {
+		sendError(c, http.StatusBadRequest, "ERD schema is immutable")
+		return
+	}
+
+	original := *erd
+
+	if req.Name != "" {
+		erd.Name = req.Name
+	}
+
+	if req.Description != "" {
+		erd.Description = req.Description
+	}
+
+	if req.Enabled != nil {
+		erd.Enabled = *req.Enabled
+	}
+
+	tx, err := r.DB.BeginTx(c.Request.Context(), nil)
+	if err != nil {
+		sendError(c, http.StatusBadRequest, "error starting update transaction: "+err.Error())
+		return
+	}
+
+	if _, err := erd.Update(c.Request.Context(), tx, boil.Infer()); err != nil {
+		msg := fmt.Sprintf("error updating erd: %s. rolling back\n", err.Error())
+
+		if err := tx.Rollback(); err != nil {
+			msg += fmt.Sprintf("error rolling back transaction: %s", err.Error())
+		}
+
+		sendError(c, http.StatusBadRequest, msg)
+
+		return
+	}
+
+	event, err := dbtools.AuditExtensionResourceDefinitionUpdated(
+		c.Request.Context(),
+		tx,
+		getCtxAuditID(c),
+		getCtxUser(c),
+		&original,
+		erd,
+	)
+	if err != nil {
+		msg := fmt.Sprintf("error updating ERD (audit): %s", err.Error())
+
+		if err := tx.Rollback(); err != nil {
+			msg += fmt.Sprintf("error rolling back transaction: %s", err.Error())
+		}
+
+		sendError(c, http.StatusBadRequest, msg)
+
+		return
+	}
+
+	if err := updateContextWithAuditEventData(c, event); err != nil {
+		msg := fmt.Sprintf("error updating ERD: %s", err.Error())
+
+		if err := tx.Rollback(); err != nil {
+			msg += fmt.Sprintf("error rolling back transaction: %s", err.Error())
+		}
+
+		sendError(c, http.StatusBadRequest, msg)
+
+		return
+	}
+
+	if err := tx.Commit(); err != nil {
+		msg := fmt.Sprintf("error committing ERD update: %s", err.Error())
+
+		if err := tx.Rollback(); err != nil {
+			msg += fmt.Sprintf("error rolling back transaction: %s", err.Error())
+		}
+
+		sendError(c, http.StatusBadRequest, msg)
+
+		return
+	}
+
+	err = r.EventBus.Publish(
+		c.Request.Context(),
+		events.GovernorExtensionResourceDefinitionsEventSubject,
+		&events.Event{
+			Version:                       events.Version,
+			Action:                        events.GovernorEventUpdate,
+			AuditID:                       c.GetString(ginaudit.AuditIDContextKey),
+			ActorID:                       getCtxActorID(c),
+			ExtensionID:                   extension.ID,
+			ExtensionResourceDefinitionID: erd.ID,
+		},
+	)
+	if err != nil {
+		sendError(
+			c,
+			http.StatusBadRequest,
+			fmt.Sprintf(
+				"failed to publish extension update event: %s\n%s",
+				err.Error(),
+				"downstream changes may be delayed",
+			),
+		)
+
+		return
+	}
+
+	c.JSON(http.StatusAccepted, erd)
+}

--- a/pkg/api/v1alpha1/extension_resource_definitions.go
+++ b/pkg/api/v1alpha1/extension_resource_definitions.go
@@ -29,11 +29,16 @@ type ExtensionResourceDefinition struct {
 // ExtensionResourceDefinitionScope is an enum type for scopes in an ERD
 type ExtensionResourceDefinitionScope string
 
+// String converts an ExtensionResourceDefinitionScope to a string
+func (scope ExtensionResourceDefinitionScope) String() string {
+	return string(scope)
+}
+
 const (
 	// ExtensionResourceDefinitionScopeUser represents the `user` scope
 	ExtensionResourceDefinitionScopeUser ExtensionResourceDefinitionScope = "user"
 	// ExtensionResourceDefinitionScopeSys represents the `system` scope
-	ExtensionResourceDefinitionScopeSys = "system"
+	ExtensionResourceDefinitionScopeSys ExtensionResourceDefinitionScope = "system"
 )
 
 // ExtensionResourceDefinitionReq is a request to create an extension resource definition

--- a/pkg/api/v1alpha1/extension_resource_definitions_test.go
+++ b/pkg/api/v1alpha1/extension_resource_definitions_test.go
@@ -1,0 +1,1171 @@
+package v1alpha1
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cockroachdb/cockroach-go/v2/testserver"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/metal-toolbox/auditevent/ginaudit"
+	dbm "github.com/metal-toolbox/governor-api/db"
+	"github.com/metal-toolbox/governor-api/internal/eventbus"
+	"github.com/metal-toolbox/governor-api/internal/models"
+	events "github.com/metal-toolbox/governor-api/pkg/events/v1alpha1"
+	"github.com/pressly/goose/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"go.hollow.sh/toolbox/ginauth"
+	"go.uber.org/zap"
+)
+
+type ExtensionResourceDefinitionsTestSuite struct {
+	suite.Suite
+
+	db   *sql.DB
+	conn *mockNATSConn
+}
+
+func (s *ExtensionResourceDefinitionsTestSuite) seedTestDB() error {
+	testData := []string{
+		// extensions
+		`INSERT INTO extensions (id, name, description, enabled, slug, status) 
+		VALUES ('00000001-0000-0000-0000-000000000001', 'Test Extension 1', 'some extension', true, 'test-extension-1', 'online');`,
+		`INSERT INTO extensions (id, name, description, enabled, slug, status) 
+		VALUES ('00000001-0000-0000-0000-000000000002', 'Test Extension 2', 'some extension', true, 'test-extension-2', 'online');`,
+		`INSERT INTO extensions (id, name, description, enabled, slug, status) 
+		VALUES ('00000001-0000-0000-0000-000000000003', 'Test Extension 2', 'some extension', true, 'test-extension-3', 'online');`,
+
+		// ERDs
+		`
+		INSERT INTO extension_resource_definitions (id, name, description, enabled, slug_singular, slug_plural, version, scope, schema, extension_id) 
+		VALUES ('00000002-0000-0000-0000-000000000001', 'User Resource', 'some-description', true, 'user-resource', 'user-resources', 'v1', 'user',
+		'{"$id": "v1.person.test-ex-1","$schema": "https://json-schema.org/draft/2020-12/schema","title": "Person","type": "object","unique": ["firstName", "lastName"],"required": ["firstName", "lastName"],"properties": {"firstName": {"type": "string","description": "The person''s first name.","ui": {"hide": true}},"lastName": {"type": "string","description": "The person''s last name."},"age": {"description": "Age in years which must be equal to or greater than zero.","type": "integer","minimum": 0}}}'::jsonb,
+		'00000001-0000-0000-0000-000000000001');
+		`,
+		`
+		INSERT INTO extension_resource_definitions (id, name, description, enabled, slug_singular, slug_plural, version, scope, schema, extension_id, deleted_at) 
+		VALUES ('00000002-0000-0000-0000-000000000002', 'User Resource', 'some-description', true, 'user-resource', 'user-resources', 'v1', 'user',
+		'{"$id": "v1.person.test-ex-1","$schema": "https://json-schema.org/draft/2020-12/schema","title": "Person","type": "object","unique": ["firstName", "lastName"],"required": ["firstName", "lastName"],"properties": {"firstName": {"type": "string","description": "The person''s first name.","ui": {"hide": true}},"lastName": {"type": "string","description": "The person''s last name."},"age": {"description": "Age in years which must be equal to or greater than zero.","type": "integer","minimum": 0}}}'::jsonb,
+		'00000001-0000-0000-0000-000000000001', '2023-07-12 12:00:00.000000+00');
+		`,
+
+		`
+		INSERT INTO extension_resource_definitions (id, name, description, enabled, slug_singular, slug_plural, version, scope, schema, extension_id) 
+		VALUES ('00000002-0001-0000-0000-000000000001', 'User Resource', 'some-description', true, 'user-resource', 'user-resources', 'v1', 'user',
+		'{"$id": "v1.person.test-ex-1","$schema": "https://json-schema.org/draft/2020-12/schema","title": "Person","type": "object","unique": ["firstName", "lastName"],"required": ["firstName", "lastName"],"properties": {"firstName": {"type": "string","description": "The person''s first name.","ui": {"hide": true}},"lastName": {"type": "string","description": "The person''s last name."},"age": {"description": "Age in years which must be equal to or greater than zero.","type": "integer","minimum": 0}}}'::jsonb,
+		'00000001-0000-0000-0000-000000000003');
+		`,
+		`
+		INSERT INTO extension_resource_definitions (id, name, description, enabled, slug_singular, slug_plural, version, scope, schema, extension_id) 
+		VALUES ('00000002-0001-0000-0000-000000000002', 'User Resource', 'some-description', true, 'user-1-resource', 'user-1-resources', 'v1', 'user',
+		'{"$id": "v1.person.test-ex-1","$schema": "https://json-schema.org/draft/2020-12/schema","title": "Person","type": "object","unique": ["firstName", "lastName"],"required": ["firstName", "lastName"],"properties": {"firstName": {"type": "string","description": "The person''s first name.","ui": {"hide": true}},"lastName": {"type": "string","description": "The person''s last name."},"age": {"description": "Age in years which must be equal to or greater than zero.","type": "integer","minimum": 0}}}'::jsonb,
+		'00000001-0000-0000-0000-000000000003');
+		`,
+	}
+
+	for _, q := range testData {
+		_, err := s.db.Query(q)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *ExtensionResourceDefinitionsTestSuite) v1alpha1() *Router {
+	return &Router{
+		AdminGroups: []string{"governor-admin"},
+		AuthMW:      &ginauth.MultiTokenMiddleware{},
+		AuditMW:     ginaudit.NewJSONMiddleware("governor-api", io.Discard),
+		DB:          sqlx.NewDb(s.db, "postgres"),
+		EventBus:    eventbus.NewClient(eventbus.WithNATSConn(s.conn)),
+		Logger:      &zap.Logger{},
+	}
+}
+
+func (s *ExtensionResourceDefinitionsTestSuite) SetupSuite() {
+	s.conn = &mockNATSConn{}
+
+	gin.SetMode(gin.TestMode)
+
+	ts, err := testserver.NewTestServer()
+	if err != nil {
+		panic(err)
+	}
+
+	s.db, err = sql.Open("postgres", ts.PGURL().String())
+	if err != nil {
+		panic(err)
+	}
+
+	goose.SetBaseFS(dbm.Migrations)
+
+	if err := goose.Up(s.db, "migrations"); err != nil {
+		panic("migration failed - could not set up test db")
+	}
+
+	if err := s.seedTestDB(); err != nil {
+		panic("db setup failed - could not seed test db: " + err.Error())
+	}
+}
+
+func (s *ExtensionResourceDefinitionsTestSuite) TestCreateExtensionResourceDefinition() {
+	r := s.v1alpha1()
+
+	tests := []struct {
+		name                 string
+		url                  string
+		payload              string
+		params               gin.Params
+		expectedResp         *ExtensionResourceDefinition
+		expectedStatus       int
+		expectedErrMsg       string
+		expectedEventSubject string
+		expectedEventPayload *events.Event
+	}{
+		{
+			name:                 "ok",
+			url:                  "/api/v1alpha1/extensions/test-extension-2",
+			expectedStatus:       http.StatusAccepted,
+			expectedEventSubject: "events.extension.erds",
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-2"},
+			},
+			expectedEventPayload: &events.Event{
+				Action:      events.GovernorEventCreate,
+				ExtensionID: "00000001-0000-0000-0000-000000000002",
+			},
+			payload: `{
+				"name": "Test ERD 1",
+				"description": "some test",
+				"slug_singular": "test-1-resource",
+				"slug_plural": "test-1-resources",
+				"version": "v1",
+				"schema": {
+					"$id": "v1.test-1-resource.test-ex-1",
+					"$schema": "https://json-schema.org/draft/2020-12/schema",
+					"title": "Test 1 ERD",
+					"type": "object",
+					"required": [ "firstName", "lastName" ],
+					"properties": {
+						"firstName": {
+							"type": "string",
+							"description": "The person's first name.",
+							"ui": {
+								"hide": true
+							}
+						},
+						"lastName": {
+							"type": "string",
+							"description": "The person's last name."
+						},
+						"age": {
+							"description": "Age in years which must be equal to or greater than zero.",
+							"type": "integer",
+							"minimum": 0
+						}
+					}
+				},
+				"enabled": true,
+				"scope": "system"
+			}`,
+			expectedResp: &ExtensionResourceDefinition{&models.ExtensionResourceDefinition{
+				Name:         "Test ERD 1",
+				Description:  "some test",
+				SlugSingular: "test-1-resource",
+				SlugPlural:   "test-1-resources",
+				Version:      "v1",
+				Scope:        "system",
+				Enabled:      true,
+			}},
+		},
+		{
+			name:                 "create by extension ID",
+			url:                  "/api/v1alpha1/extensions/00000001-0000-0000-0000-000000000002",
+			expectedStatus:       http.StatusAccepted,
+			expectedEventSubject: "events.extension.erds",
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-2"},
+			},
+			expectedEventPayload: &events.Event{
+				Action:      events.GovernorEventCreate,
+				ExtensionID: "00000001-0000-0000-0000-000000000002",
+			},
+			payload: `{
+				"name": "Test ERD 1",
+				"description": "some test",
+				"slug_singular": "test-1-resource",
+				"slug_plural": "test-1-resources",
+				"version": "v2",
+				"schema": {
+					"$id": "v2.test-1-resource.test-ex-1",
+					"$schema": "https://json-schema.org/draft/2020-12/schema",
+					"title": "Test 1 ERD",
+					"type": "object",
+					"required": [ "firstName", "lastName" ],
+					"properties": {
+						"firstName": {
+							"type": "string",
+							"description": "The person's first name.",
+							"ui": {
+								"hide": true
+							}
+						},
+						"lastName": {
+							"type": "string",
+							"description": "The person's last name."
+						},
+						"age": {
+							"description": "Age in years which must be equal to or greater than zero.",
+							"type": "integer",
+							"minimum": 0
+						}
+					}
+				},
+				"enabled": true,
+				"scope": "system"
+			}`,
+			expectedResp: &ExtensionResourceDefinition{&models.ExtensionResourceDefinition{
+				Name:         "Test ERD 1",
+				Description:  "some test",
+				SlugSingular: "test-1-resource",
+				SlugPlural:   "test-1-resources",
+				Version:      "v1",
+				Scope:        "system",
+				Enabled:      true,
+			}},
+		},
+		{
+			name:           "bad schema",
+			url:            "/api/v1alpha1/extensions/test-extension-2",
+			expectedStatus: http.StatusBadRequest,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-2"},
+			},
+			payload: `{
+				"name": "Test ERD 1",
+				"description": "some test",
+				"slug_singular": "test-1-resource",
+				"slug_plural": "test-1-resources",
+				"version": "v1",
+				"schema": "{",
+				"enabled": true,
+				"scope": "system"
+			}`,
+			expectedErrMsg: "ERD schema is not valid",
+		},
+		{
+			name:           "extension not found",
+			url:            "/api/v1alpha1/extensions/non-exists-extension",
+			expectedStatus: http.StatusNotFound,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "non-exists-extension"},
+			},
+			expectedErrMsg: "extension not found",
+			payload: `{
+				"name": "Test ERD 1",
+				"slug_singular": "test-1-resource",
+				"slug_plural": "test-1-resources",
+				"version": "v2",
+				"schema": {},
+				"enabled": true,
+				"scope": "system"
+			}`,
+		},
+		{
+			name:           "missing name",
+			url:            "/api/v1alpha1/extensions/test-extension-2",
+			expectedStatus: http.StatusBadRequest,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-2"},
+			},
+			payload: `{
+					"slug_singular": "test-1-resource",
+					"slug_plural": "test-1-resources",
+					"version": "v2",
+					"schema": {},
+					"enabled": true,
+					"scope": "system"
+			}`,
+			expectedErrMsg: "name is required",
+		},
+		{
+			name:           "missing slug_singular",
+			url:            "/api/v1alpha1/extensions/test-extension-2",
+			expectedStatus: http.StatusBadRequest,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-2"},
+			},
+			payload: `{
+					"name": "Test ERD 1",
+					"slug_plural": "test-1-resources",
+					"version": "v2",
+					"schema": {},
+					"enabled": true,
+					"scope": "system"
+			}`,
+			expectedErrMsg: "ERD slugs are required",
+		},
+		{
+			name:           "missing slug_plural",
+			url:            "/api/v1alpha1/extensions/test-extension-2",
+			expectedStatus: http.StatusBadRequest,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-2"},
+			},
+			payload: `{
+					"name": "Test ERD 1",
+					"slug_singular": "test-1-resource",
+					"version": "v2",
+					"schema": {},
+					"enabled": true,
+					"scope": "system"
+			}`,
+			expectedErrMsg: "ERD slugs are required",
+		},
+		{
+			name:           "missing version",
+			url:            "/api/v1alpha1/extensions/test-extension-2",
+			expectedStatus: http.StatusBadRequest,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-2"},
+			},
+			payload: `{
+					"name": "Test ERD 1",
+					"slug_singular": "test-1-resource",
+					"slug_plural": "test-1-resources",
+					"schema": {},
+					"enabled": true,
+					"scope": "system"
+			}`,
+			expectedErrMsg: "version is required",
+		},
+		{
+			name:           "missing schema",
+			url:            "/api/v1alpha1/extensions/test-extension-2",
+			expectedStatus: http.StatusBadRequest,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-2"},
+			},
+			payload: `{
+					"name": "Test ERD 1",
+					"slug_singular": "test-1-resource",
+					"slug_plural": "test-1-resources",
+					"version": "v2",
+					"enabled": true,
+					"scope": "system"
+			}`,
+			expectedErrMsg: "schema is required",
+		},
+		{
+			name:           "missing enabled",
+			url:            "/api/v1alpha1/extensions/test-extension-2",
+			expectedStatus: http.StatusBadRequest,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-2"},
+			},
+			payload: `{
+					"name": "Test ERD 1",
+					"slug_singular": "test-1-resource",
+					"slug_plural": "test-1-resources",
+					"version": "v2",
+					"schema": {},
+					"scope": "system"
+			}`,
+			expectedErrMsg: "enabled is required",
+		},
+		{
+			name:           "missing scope",
+			url:            "/api/v1alpha1/extensions/test-extension-2",
+			expectedStatus: http.StatusBadRequest,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-2"},
+			},
+			payload: `{
+					"name": "Test ERD 1",
+					"slug_singular": "test-1-resource",
+					"slug_plural": "test-1-resources",
+					"version": "v2",
+					"schema": {},
+					"enabled": true
+			}`,
+			expectedErrMsg: "scope is required",
+		},
+		{
+			name:           "bad scope",
+			url:            "/api/v1alpha1/extensions/test-extension-2",
+			expectedStatus: http.StatusBadRequest,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-2"},
+			},
+			payload: `{
+					"name": "Test ERD 1",
+					"slug_singular": "test-1-resource",
+					"slug_plural": "test-1-resources",
+					"version": "v2",
+					"scope": "bad scope",
+					"schema": {},
+					"enabled": true
+			}`,
+			expectedErrMsg: "invalid ERD scope",
+		},
+		{
+			name:                 "slug singular conflict",
+			url:                  "/api/v1alpha1/extensions/00000001-0000-0000-0000-000000000002",
+			expectedStatus:       http.StatusBadRequest,
+			expectedEventSubject: "events.extension.erds",
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "00000001-0000-0000-0000-000000000002"},
+			},
+			payload: `{
+				"name": "Test ERD 1",
+				"description": "some test",
+				"slug_singular": "test-1-resource",
+				"slug_plural": "test-1-resources",
+				"version": "v2",
+				"schema": {},
+				"enabled": true,
+				"scope": "system"
+			}`,
+			expectedErrMsg: "duplicate key value violates unique constraint",
+		},
+		{
+			name:                 "slug plural conflict",
+			url:                  "/api/v1alpha1/extensions/00000001-0000-0000-0000-000000000002",
+			expectedStatus:       http.StatusBadRequest,
+			expectedEventSubject: "events.extension.erds",
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "00000001-0000-0000-0000-000000000002"},
+			},
+			payload: `{
+				"name": "Test ERD 1",
+				"description": "some test",
+				"slug_singular": "test-11-resource",
+				"slug_plural": "test-1-resources",
+				"version": "v2",
+				"schema": {},
+				"enabled": true,
+				"scope": "system"
+			}`,
+			expectedErrMsg: "duplicate key value violates unique constraint",
+		},
+		{
+			name:                 "duplicate slug in different extension",
+			url:                  "/api/v1alpha1/extensions/00000001-0000-0000-0000-000000000003",
+			expectedStatus:       http.StatusAccepted,
+			expectedEventSubject: "events.extension.erds",
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "00000001-0000-0000-0000-000000000003"},
+			},
+			payload: `{
+				"name": "Test ERD 1",
+				"description": "some test",
+				"slug_singular": "test-1-resource",
+				"slug_plural": "test-1-resources",
+				"version": "v2",
+				"schema": {},
+				"enabled": true,
+				"scope": "system"
+			}`,
+			expectedEventPayload: &events.Event{
+				Action:      events.GovernorEventCreate,
+				ExtensionID: "00000001-0000-0000-0000-000000000003",
+			},
+			expectedResp: &ExtensionResourceDefinition{&models.ExtensionResourceDefinition{
+				Name:         "Test ERD 1",
+				Description:  "some test",
+				SlugSingular: "test-1-resource",
+				SlugPlural:   "test-1-resources",
+				Version:      "v1",
+				Scope:        "system",
+				Enabled:      true,
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			auditID := uuid.New().String()
+
+			req, _ := http.NewRequest("POST", tt.url, nil)
+			req = req.WithContext(context.Background())
+			req.Body = io.NopCloser(bytes.NewBufferString(tt.payload))
+			c.Request = req
+			c.Params = tt.params
+			c.Set(ginaudit.AuditIDContextKey, auditID)
+
+			r.createExtensionResourceDefinition(c)
+
+			assert.Equal(t, tt.expectedStatus, w.Code, "Expected status %d, got %d", tt.expectedStatus, w.Code)
+
+			if tt.expectedErrMsg != "" {
+				body := w.Body.String()
+				assert.Contains(
+					t, body, tt.expectedErrMsg,
+					"Expected error message to contain %q, got %s", tt.expectedErrMsg, body,
+				)
+
+				return
+			}
+
+			event := &events.Event{}
+			err := json.Unmarshal(s.conn.Payload, event)
+			assert.Nil(t, err)
+
+			erd := &ExtensionResourceDefinition{}
+			body := w.Body.String()
+			err = json.Unmarshal([]byte(body), erd)
+			assert.Nil(t, err)
+
+			assert.Equal(
+				t, tt.expectedResp.Name, erd.Name,
+				"Expected ERD name %s, got %s", t, tt.expectedResp.Name, erd.Name,
+			)
+
+			assert.Equal(
+				t, tt.expectedResp.SlugSingular, erd.SlugSingular,
+				"Expected ERD singular slug %s, got %s", t, tt.expectedResp.SlugSingular, erd.SlugSingular,
+			)
+
+			assert.Equal(
+				t, tt.expectedResp.SlugPlural, erd.SlugPlural,
+				"Expected ERD plural slug %s, got %s", t, tt.expectedResp.SlugPlural, erd.SlugPlural,
+			)
+
+			assert.Equal(
+				t, tt.expectedResp.Description, erd.Description,
+				"Expected ERD description %s, got %s", t, tt.expectedResp.Description, erd.Description,
+			)
+
+			assert.Equal(
+				t, tt.expectedResp.Scope, erd.Scope,
+				"Expected ERD scope %s, got %s", t, tt.expectedResp.Scope, erd.Scope,
+			)
+
+			assert.Equal(
+				t, tt.expectedResp.Enabled, erd.Enabled,
+			)
+
+			assert.Equal(
+				t, tt.expectedEventSubject, s.conn.Subject,
+				"Expected event subject %s, got %s", tt.expectedEventSubject, s.conn.Subject,
+			)
+
+			assert.Equal(
+				t, tt.expectedEventPayload.Action, event.Action,
+				"Expected event action %s, got %s", tt.expectedEventPayload.Action, event.Action,
+			)
+
+			assert.Equal(
+				t, tt.expectedEventPayload.ExtensionID, event.ExtensionID,
+				"Expected event extension ID to match response ID",
+			)
+
+			assert.Equal(
+				t, erd.ID, event.ExtensionResourceDefinitionID,
+				"Expected event ERD ID to match response ID",
+			)
+		})
+	}
+}
+
+func (s *ExtensionResourceDefinitionsTestSuite) TestListExtensionResourceDefinitions() {
+	r := s.v1alpha1()
+
+	tests := []struct {
+		name           string
+		url            string
+		params         gin.Params
+		expectedStatus int
+		expectedErrMsg string
+		expectedCount  int
+	}{
+		{
+			name:           "list by ID",
+			url:            "/api/v1alpha1/extensions/00000001-0000-0000-0000-000000000001/erds",
+			expectedStatus: http.StatusOK,
+			expectedCount:  1,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "00000001-0000-0000-0000-000000000001"},
+			},
+		},
+		{
+			name:           "list by slug",
+			url:            "/api/v1alpha1/extensions/test-extension-1/erds",
+			expectedStatus: http.StatusOK,
+			expectedCount:  1,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-1"},
+			},
+		},
+		{
+			name:           "list by ID deleted",
+			url:            "/api/v1alpha1/extensions/00000001-0000-0000-0000-000000000001/erds?deleted",
+			expectedStatus: http.StatusOK,
+			expectedCount:  2,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "00000001-0000-0000-0000-000000000001"},
+			},
+		},
+		{
+			name:           "list by slug deleted",
+			url:            "/api/v1alpha1/extensions/test-extension-1/erds?deleted",
+			expectedStatus: http.StatusOK,
+			expectedCount:  2,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-1"},
+			},
+		},
+		{
+			name:           "extension not found",
+			url:            "/api/v1alpha1/extensions/non-existence/erds",
+			expectedStatus: http.StatusNotFound,
+			expectedErrMsg: "extension not found",
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "non-existence"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			auditID := uuid.New().String()
+
+			req, _ := http.NewRequest("GET", tt.url, nil)
+			req = req.WithContext(context.Background())
+			c.Request = req
+			c.Params = tt.params
+			c.Set(ginaudit.AuditIDContextKey, auditID)
+
+			r.listExtensionResourceDefinitions(c)
+
+			assert.Equal(t, tt.expectedStatus, w.Code, "Expected status %d, got %d", tt.expectedStatus, w.Code)
+
+			if tt.expectedErrMsg != "" {
+				body := w.Body.String()
+				assert.Contains(
+					t, body, tt.expectedErrMsg,
+					"Expected error message to contain %q, got %s", tt.expectedErrMsg, body,
+				)
+
+				return
+			}
+
+			body := w.Body.String()
+			resp := []interface{}{}
+			err := json.Unmarshal([]byte(body), &resp)
+
+			assert.Nil(t, err, "expecting unmarshal err to be nil")
+			assert.Equal(t, tt.expectedCount, len(resp))
+		})
+	}
+}
+
+func (s *ExtensionResourceDefinitionsTestSuite) TestGetExtensionResourceDefinition() {
+	r := s.v1alpha1()
+
+	tests := []struct {
+		name           string
+		url            string
+		params         gin.Params
+		expectedStatus int
+		expectedErrMsg string
+	}{
+		{
+			name:           "get by ID ok",
+			url:            "/api/v1alpha1/extensions/00000001-0000-0000-0000-000000000001/erds/00000002-0000-0000-0000-000000000001",
+			expectedStatus: http.StatusOK,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "00000001-0000-0000-0000-000000000001"},
+				gin.Param{Key: "erd-id-slug", Value: "00000002-0000-0000-0000-000000000001"},
+			},
+		},
+		{
+			name:           "get by slug ok",
+			url:            "/api/v1alpha1/extensions/test-extension-1/erds/user-resource/v1`",
+			expectedStatus: http.StatusOK,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-1"},
+				gin.Param{Key: "erd-id-slug", Value: "user-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+		},
+		{
+			name:           "get deleted ok",
+			url:            "/api/v1alpha1/extensions/test-extension-1/erds/00000002-0000-0000-0000-000000000002?deleted",
+			expectedStatus: http.StatusOK,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-1"},
+				gin.Param{Key: "erd-id-slug", Value: "00000002-0000-0000-0000-000000000002"},
+			},
+		},
+		{
+			name:           "get deleted by slug",
+			url:            "/api/v1alpha1/extensions/test-extension-1/erds/user-resource/v1?deleted",
+			expectedStatus: http.StatusBadRequest,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-1"},
+				gin.Param{Key: "erd-id-slug", Value: "user-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+		},
+		{
+			name:           "extension not found",
+			url:            "/api/v1alpha1/extensions/nonexistent-extension/erds/some-resource/v1",
+			expectedStatus: http.StatusNotFound,
+			expectedErrMsg: "extension does not exist",
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "nonexistent-extension"},
+				gin.Param{Key: "erd-id-slug", Value: "some-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			auditID := uuid.New().String()
+
+			req, _ := http.NewRequest("GET", tt.url, nil)
+			req = req.WithContext(context.Background())
+			c.Request = req
+			c.Params = tt.params
+			c.Set(ginaudit.AuditIDContextKey, auditID)
+
+			r.getExtensionResourceDefinition(c)
+
+			assert.Equal(t, tt.expectedStatus, w.Code, "Expected status %d, got %d", tt.expectedStatus, w.Code)
+
+			if tt.expectedErrMsg != "" {
+				body := w.Body.String()
+				assert.Contains(
+					t, body, tt.expectedErrMsg,
+					"Expected error message to contain %q, got %s", tt.expectedErrMsg, body,
+				)
+
+				return
+			}
+		})
+	}
+}
+
+func (s *ExtensionResourceDefinitionsTestSuite) TestUpdateExtensionResourceDefinition() {
+	r := s.v1alpha1()
+
+	tests := []struct {
+		name                 string
+		url                  string
+		params               gin.Params
+		payload              string
+		expectedResp         *ExtensionResourceDefinition
+		expectedStatus       int
+		expectedErrMsg       string
+		expectedEventSubject string
+		expectedEventPayload *events.Event
+	}{
+		{
+			name:                 "update by ID ok",
+			url:                  "/api/v1alpha1/extensions/00000001-0000-0000-0000-000000000001/erds/00000002-0000-0000-0000-000000000001",
+			expectedStatus:       http.StatusAccepted,
+			payload:              `{ "description": "some test 1" }`,
+			expectedEventSubject: "events.extension.erds",
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "00000001-0000-0000-0000-000000000001"},
+				gin.Param{Key: "erd-id-slug", Value: "00000002-0000-0000-0000-000000000001"},
+			},
+			expectedEventPayload: &events.Event{
+				Action:                        events.GovernorEventUpdate,
+				ExtensionID:                   "00000001-0000-0000-0000-000000000001",
+				ExtensionResourceDefinitionID: "00000002-0000-0000-0000-000000000001",
+			},
+			expectedResp: &ExtensionResourceDefinition{&models.ExtensionResourceDefinition{
+				Name:         "User Resource",
+				Description:  "some test 1",
+				SlugSingular: "user-resource",
+				SlugPlural:   "user-resources",
+				Version:      "v1",
+				Scope:        "user",
+				Enabled:      true,
+			}},
+		},
+		{
+			name:                 "update by slug ok",
+			url:                  "/api/v1alpha1/extensions/test-extension-1/erds/user-resource/v1`",
+			expectedStatus:       http.StatusAccepted,
+			expectedEventSubject: "events.extension.erds",
+			payload:              `{ "description": "some test 1" }`,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-1"},
+				gin.Param{Key: "erd-id-slug", Value: "user-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+			expectedEventPayload: &events.Event{
+				Action:                        events.GovernorEventUpdate,
+				ExtensionID:                   "00000001-0000-0000-0000-000000000001",
+				ExtensionResourceDefinitionID: "00000002-0000-0000-0000-000000000001",
+			},
+			expectedResp: &ExtensionResourceDefinition{&models.ExtensionResourceDefinition{
+				Name:         "User Resource",
+				Description:  "some test 1",
+				SlugSingular: "user-resource",
+				SlugPlural:   "user-resources",
+				Version:      "v1",
+				Scope:        "user",
+				Enabled:      true,
+			}},
+		},
+		{
+			name:           "extension not found",
+			url:            "/api/v1alpha1/extensions/nonexistent-extension/erds/some-resource/v1",
+			expectedStatus: http.StatusNotFound,
+			expectedErrMsg: "extension does not exist",
+			payload:        `{}`,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "nonexistent-extension"},
+				gin.Param{Key: "erd-id-slug", Value: "some-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+		},
+		{
+			name:           "attempt modify slug singular",
+			url:            "/api/v1alpha1/extensions/test-extension-1/erds/user-resource/v1`",
+			payload:        `{ "slug_singular": "user-resource-1" }`,
+			expectedErrMsg: "ERD slugs are immutable",
+			expectedStatus: http.StatusBadRequest,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-1"},
+				gin.Param{Key: "erd-id-slug", Value: "user-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+		},
+		{
+			name:                 "include unmodified slug singular",
+			url:                  "/api/v1alpha1/extensions/test-extension-1/erds/user-resource/v1`",
+			payload:              `{ "slug_singular": "user-resource" }`,
+			expectedEventSubject: "events.extension.erds",
+			expectedStatus:       http.StatusAccepted,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-1"},
+				gin.Param{Key: "erd-id-slug", Value: "user-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+			expectedEventPayload: &events.Event{
+				Action:                        events.GovernorEventUpdate,
+				ExtensionID:                   "00000001-0000-0000-0000-000000000001",
+				ExtensionResourceDefinitionID: "00000002-0000-0000-0000-000000000001",
+			},
+			expectedResp: &ExtensionResourceDefinition{&models.ExtensionResourceDefinition{
+				Name:         "User Resource",
+				Description:  "some test 1",
+				SlugSingular: "user-resource",
+				SlugPlural:   "user-resources",
+				Version:      "v1",
+				Scope:        "user",
+				Enabled:      true,
+			}},
+		},
+		{
+			name:           "attempt modify slug plural",
+			url:            "/api/v1alpha1/extensions/test-extension-1/erds/user-resource/v1`",
+			payload:        `{ "slug_plural": "user-resource-1" }`,
+			expectedErrMsg: "ERD slugs are immutable",
+			expectedStatus: http.StatusBadRequest,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-1"},
+				gin.Param{Key: "erd-id-slug", Value: "user-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+		},
+		{
+			name:                 "include unmodified slug plural",
+			url:                  "/api/v1alpha1/extensions/test-extension-1/erds/user-resource/v1`",
+			payload:              `{ "slug_plural": "user-resources" }`,
+			expectedEventSubject: "events.extension.erds",
+			expectedStatus:       http.StatusAccepted,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-1"},
+				gin.Param{Key: "erd-id-slug", Value: "user-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+			expectedEventPayload: &events.Event{
+				Action:                        events.GovernorEventUpdate,
+				ExtensionID:                   "00000001-0000-0000-0000-000000000001",
+				ExtensionResourceDefinitionID: "00000002-0000-0000-0000-000000000001",
+			},
+			expectedResp: &ExtensionResourceDefinition{&models.ExtensionResourceDefinition{
+				Name:         "User Resource",
+				Description:  "some test 1",
+				SlugSingular: "user-resource",
+				SlugPlural:   "user-resources",
+				Version:      "v1",
+				Scope:        "user",
+				Enabled:      true,
+			}},
+		},
+		{
+			name:           "attempt modify scope",
+			url:            "/api/v1alpha1/extensions/test-extension-1/erds/user-resource/v1`",
+			payload:        `{ "scope": "system" }`,
+			expectedErrMsg: "ERD scope is immutable",
+			expectedStatus: http.StatusBadRequest,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-1"},
+				gin.Param{Key: "erd-id-slug", Value: "user-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+		},
+		{
+			name:                 "include unmodified scope",
+			url:                  "/api/v1alpha1/extensions/test-extension-1/erds/user-resource/v1`",
+			payload:              `{ "scope": "user" }`,
+			expectedEventSubject: "events.extension.erds",
+			expectedStatus:       http.StatusAccepted,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-1"},
+				gin.Param{Key: "erd-id-slug", Value: "user-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+			expectedEventPayload: &events.Event{
+				Action:                        events.GovernorEventUpdate,
+				ExtensionID:                   "00000001-0000-0000-0000-000000000001",
+				ExtensionResourceDefinitionID: "00000002-0000-0000-0000-000000000001",
+			},
+			expectedResp: &ExtensionResourceDefinition{&models.ExtensionResourceDefinition{
+				Name:         "User Resource",
+				Description:  "some test 1",
+				SlugSingular: "user-resource",
+				SlugPlural:   "user-resources",
+				Version:      "v1",
+				Scope:        "user",
+				Enabled:      true,
+			}},
+		},
+		{
+			name:           "attempt modify version",
+			url:            "/api/v1alpha1/extensions/test-extension-1/erds/user-resource/v1`",
+			payload:        `{ "version": "v2" }`,
+			expectedErrMsg: "ERD version is immutable",
+			expectedStatus: http.StatusBadRequest,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-1"},
+				gin.Param{Key: "erd-id-slug", Value: "user-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+		},
+		{
+			name:                 "include unmodified version",
+			url:                  "/api/v1alpha1/extensions/test-extension-1/erds/user-resource/v1`",
+			payload:              `{ "version": "v1" }`,
+			expectedEventSubject: "events.extension.erds",
+			expectedStatus:       http.StatusAccepted,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-1"},
+				gin.Param{Key: "erd-id-slug", Value: "user-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+			expectedEventPayload: &events.Event{
+				Action:                        events.GovernorEventUpdate,
+				ExtensionID:                   "00000001-0000-0000-0000-000000000001",
+				ExtensionResourceDefinitionID: "00000002-0000-0000-0000-000000000001",
+			},
+			expectedResp: &ExtensionResourceDefinition{&models.ExtensionResourceDefinition{
+				Name:         "User Resource",
+				Description:  "some test 1",
+				SlugSingular: "user-resource",
+				SlugPlural:   "user-resources",
+				Version:      "v1",
+				Scope:        "user",
+				Enabled:      true,
+			}},
+		},
+		{
+			name:           "attempt modify schema",
+			url:            "/api/v1alpha1/extensions/test-extension-1/erds/user-resource/v1`",
+			payload:        `{ "schema": "{}" }`,
+			expectedErrMsg: "ERD schema is immutable",
+			expectedStatus: http.StatusBadRequest,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-1"},
+				gin.Param{Key: "erd-id-slug", Value: "user-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			auditID := uuid.New().String()
+
+			req, _ := http.NewRequest("PATCH", tt.url, nil)
+			req = req.WithContext(context.Background())
+			req.Body = io.NopCloser(bytes.NewBufferString(tt.payload))
+			c.Request = req
+			c.Params = tt.params
+			c.Set(ginaudit.AuditIDContextKey, auditID)
+
+			r.updateExtensionResourceDefinition(c)
+
+			assert.Equal(t, tt.expectedStatus, w.Code, "Expected status %d, got %d", tt.expectedStatus, w.Code)
+
+			if tt.expectedErrMsg != "" {
+				body := w.Body.String()
+				assert.Contains(
+					t, body, tt.expectedErrMsg,
+					"Expected error message to contain %q, got %s", tt.expectedErrMsg, body,
+				)
+
+				return
+			}
+
+			event := &events.Event{}
+			err := json.Unmarshal(s.conn.Payload, event)
+			assert.Nil(t, err)
+
+			erd := &ExtensionResourceDefinition{}
+			body := w.Body.String()
+			err = json.Unmarshal([]byte(body), erd)
+			assert.Nil(t, err)
+
+			assert.Equal(
+				t, tt.expectedResp.Name, erd.Name,
+				"Expected ERD name %s, got %s", t, tt.expectedResp.Name, erd.Name,
+			)
+
+			assert.Equal(
+				t, tt.expectedResp.SlugSingular, erd.SlugSingular,
+				"Expected ERD singular slug %s, got %s", t, tt.expectedResp.SlugSingular, erd.SlugSingular,
+			)
+
+			assert.Equal(
+				t, tt.expectedResp.SlugPlural, erd.SlugPlural,
+				"Expected ERD plural slug %s, got %s", t, tt.expectedResp.SlugPlural, erd.SlugPlural,
+			)
+
+			assert.Equal(
+				t, tt.expectedResp.Description, erd.Description,
+				"Expected ERD description %s, got %s", t, tt.expectedResp.Description, erd.Description,
+			)
+
+			assert.Equal(
+				t, tt.expectedResp.Scope, erd.Scope,
+				"Expected ERD scope %s, got %s", t, tt.expectedResp.Scope, erd.Scope,
+			)
+
+			assert.Equal(
+				t, tt.expectedResp.Enabled, erd.Enabled,
+			)
+
+			assert.Equal(
+				t, tt.expectedEventSubject, s.conn.Subject,
+				"Expected event subject %s, got %s", tt.expectedEventSubject, s.conn.Subject,
+			)
+
+			assert.Equal(
+				t, tt.expectedEventPayload.Action, event.Action,
+				"Expected event action %s, got %s", tt.expectedEventPayload.Action, event.Action,
+			)
+
+			assert.Equal(
+				t, tt.expectedEventPayload.ExtensionID, event.ExtensionID,
+				"Expected event extension ID to match response ID",
+			)
+
+			assert.Equal(
+				t, tt.expectedEventPayload.ExtensionResourceDefinitionID, event.ExtensionResourceDefinitionID,
+				"Expected event ERD ID to match response ID",
+			)
+		})
+	}
+}
+
+func (s *ExtensionResourceDefinitionsTestSuite) TestDeleteExtensionResourceDefinition() {
+	r := s.v1alpha1()
+
+	tests := []struct {
+		name           string
+		url            string
+		params         gin.Params
+		expectedStatus int
+		expectedErrMsg string
+	}{
+		{
+			name:           "delete by ID ok",
+			url:            "/api/v1alpha1/extensions/00000001-0000-0000-0000-000000000003/erds/00000002-0001-0000-0000-000000000001",
+			expectedStatus: http.StatusAccepted,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "00000001-0000-0000-0000-000000000003"},
+				gin.Param{Key: "erd-id-slug", Value: "00000002-0001-0000-0000-000000000001"},
+			},
+		},
+		{
+			name:           "delete by slug ok",
+			url:            "/api/v1alpha1/extensions/test-extension-3/erds/user-1-resource/v1`",
+			expectedStatus: http.StatusAccepted,
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "test-extension-3"},
+				gin.Param{Key: "erd-id-slug", Value: "user-1-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+		},
+		{
+			name:           "extension not found",
+			url:            "/api/v1alpha1/extensions/nonexistent-extension/erds/some-resource/v1",
+			expectedStatus: http.StatusNotFound,
+			expectedErrMsg: "extension does not exist",
+			params: gin.Params{
+				gin.Param{Key: "eid", Value: "nonexistent-extension"},
+				gin.Param{Key: "erd-id-slug", Value: "some-resource"},
+				gin.Param{Key: "erd-version", Value: "v1"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			auditID := uuid.New().String()
+
+			req, _ := http.NewRequest("DELETE", tt.url, nil)
+			req = req.WithContext(context.Background())
+			c.Request = req
+			c.Params = tt.params
+			c.Set(ginaudit.AuditIDContextKey, auditID)
+
+			r.deleteExtensionResourceDefinition(c)
+
+			assert.Equal(t, tt.expectedStatus, w.Code, "Expected status %d, got %d", tt.expectedStatus, w.Code)
+
+			if tt.expectedErrMsg != "" {
+				body := w.Body.String()
+				assert.Contains(
+					t, body, tt.expectedErrMsg,
+					"Expected error message to contain %q, got %s", tt.expectedErrMsg, body,
+				)
+
+				return
+			}
+		})
+	}
+}
+
+func TestExtensionResourceDefinitionsSuite(t *testing.T) {
+	suite.Run(t, new(ExtensionResourceDefinitionsTestSuite))
+}

--- a/pkg/api/v1alpha1/router.go
+++ b/pkg/api/v1alpha1/router.go
@@ -605,6 +605,63 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.mwUserAuthRequired(AuthRoleAdmin),
 		r.deleteExtension,
 	)
+
+	// extension resource definitions
+	rg.GET(
+		"/extensions/:eid/erds",
+		r.AuditMW.AuditWithType("ListExtensionResourceDefinitions"),
+		r.AuthMW.AuthRequired(readScopesWithOpenID("governor:extensions")),
+		r.listExtensionResourceDefinitions,
+	)
+
+	rg.POST(
+		"/extensions/:eid/erds",
+		r.AuditMW.AuditWithType("CreateExtensionResourceDefinition"),
+		r.AuthMW.AuthRequired(createScopesWithOpenID("governor:extensions")),
+		r.createExtensionResourceDefinition,
+	)
+
+	rg.GET(
+		"/extensions/:eid/erds/:erd-id-slug",
+		r.AuditMW.AuditWithType("GetExtensionResourceDefinitionByID"),
+		r.AuthMW.AuthRequired(readScopesWithOpenID("governor:extensions")),
+		r.getExtensionResourceDefinition,
+	)
+
+	rg.GET(
+		"/extensions/:eid/erds/:erd-id-slug/:erd-version",
+		r.AuditMW.AuditWithType("GetExtensionResourceDefinitionBySlug"),
+		r.AuthMW.AuthRequired(readScopesWithOpenID("governor:extensions")),
+		r.getExtensionResourceDefinition,
+	)
+
+	rg.PATCH(
+		"/extensions/:eid/erds/:erd-id-slug",
+		r.AuditMW.AuditWithType("UpdateExtensionResourceDefinitionByID"),
+		r.AuthMW.AuthRequired(updateScopesWithOpenID("governor:extensions")),
+		r.updateExtensionResourceDefinition,
+	)
+
+	rg.PATCH(
+		"/extensions/:eid/erds/:erd-id-slug/:erd-version",
+		r.AuditMW.AuditWithType("UpdateExtensionResourceDefinitionBySlug"),
+		r.AuthMW.AuthRequired(updateScopesWithOpenID("governor:extensions")),
+		r.updateExtensionResourceDefinition,
+	)
+
+	rg.DELETE(
+		"/extensions/:eid/erds/:erd-id-slug",
+		r.AuditMW.AuditWithType("DeleteExtensionResourceDefinitionByID"),
+		r.AuthMW.AuthRequired(deleteScopesWithOpenID("governor:extensions")),
+		r.deleteExtensionResourceDefinition,
+	)
+
+	rg.DELETE(
+		"/extensions/:eid/erds/:erd-id-slug/:erd-version",
+		r.AuditMW.AuditWithType("DeleteExtensionResourceDefinitionBySlug"),
+		r.AuthMW.AuthRequired(deleteScopesWithOpenID("governor:extensions")),
+		r.deleteExtensionResourceDefinition,
+	)
 }
 
 func contains(list []string, item string) bool {

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -51,6 +51,6 @@ var (
 	// ErrMissingExtensionIDOrSlug is returned when a missing or bad extension ID is passed to a request
 	ErrMissingExtensionIDOrSlug = errors.New("missing extension id or slug in request")
 
-	// ErrMissingERDID is returned when a a missing or bad extension resource definition ID is passed to a request
-	ErrMissingERDID = errors.New("missing extension id in request")
+	// ErrMissingERDIDOrSlug is returned when a a missing or bad extension resource definition ID is passed to a request
+	ErrMissingERDIDOrSlug = errors.New("missing ERD id or slug in request")
 )

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -50,4 +50,7 @@ var (
 
 	// ErrMissingExtensionIDOrSlug is returned when a missing or bad extension ID is passed to a request
 	ErrMissingExtensionIDOrSlug = errors.New("missing extension id or slug in request")
+
+	// ErrMissingERDID is returned when a a missing or bad extension resource definition ID is passed to a request
+	ErrMissingERDID = errors.New("missing extension id in request")
 )

--- a/pkg/client/extension_resource_definitions.go
+++ b/pkg/client/extension_resource_definitions.go
@@ -35,7 +35,7 @@ func (c *Client) ExtensionResourceDefinition(
 	}
 
 	if erdIDOrSlug == "" {
-		return nil, ErrMissingERDID
+		return nil, ErrMissingERDIDOrSlug
 	}
 
 	u := fmt.Sprintf(
@@ -208,7 +208,7 @@ func (c *Client) UpdateExtensionResourceDefinition(
 	}
 
 	if erdIDOrSlug == "" {
-		return nil, ErrMissingERDID
+		return nil, ErrMissingERDIDOrSlug
 	}
 
 	u := fmt.Sprintf(
@@ -274,7 +274,7 @@ func (c *Client) DeleteExtensionResourceDefinition(
 	}
 
 	if erdIDOrSlug == "" {
-		return ErrMissingERDID
+		return ErrMissingERDIDOrSlug
 	}
 
 	u := fmt.Sprintf(

--- a/pkg/client/extension_resource_definitions.go
+++ b/pkg/client/extension_resource_definitions.go
@@ -1,0 +1,319 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/metal-toolbox/governor-api/pkg/api/v1alpha1"
+)
+
+func handleERDStatusNotFound(respBody []byte) error {
+	respErr := map[string]string{}
+	if err := json.Unmarshal(respBody, &respErr); err != nil {
+		return err
+	}
+
+	if errMsg, ok := respErr["error"]; ok && strings.Contains(errMsg, "extension does not exist") {
+		return v1alpha1.ErrExtensionNotFound
+	}
+
+	return v1alpha1.ErrERDNotFound
+}
+
+// ExtensionResourceDefinition fetches an ERD, erd version must be provided
+// when using erd slug
+func (c *Client) ExtensionResourceDefinition(
+	ctx context.Context, extensionIDOrSlug, erdIDOrSlug, erdVersion string, deleted bool,
+) (*v1alpha1.ExtensionResourceDefinition, error) {
+	if extensionIDOrSlug == "" {
+		return nil, ErrMissingExtensionIDOrSlug
+	}
+
+	if erdIDOrSlug == "" {
+		return nil, ErrMissingERDID
+	}
+
+	u := fmt.Sprintf(
+		"%s/api/%s/extensions/%s/erds/%s",
+		c.url,
+		governorAPIVersionAlpha,
+		extensionIDOrSlug,
+		erdIDOrSlug,
+	)
+
+	if erdVersion != "" {
+		u += fmt.Sprintf("/%s", erdVersion)
+	}
+
+	if deleted {
+		u += "?deleted"
+	}
+
+	req, err := c.newGovernorRequest(ctx, http.MethodGet, u)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, handleERDStatusNotFound(respBody)
+	}
+
+	if resp.StatusCode != http.StatusOK &&
+		resp.StatusCode != http.StatusAccepted &&
+		resp.StatusCode != http.StatusNoContent {
+		return nil, ErrRequestNonSuccess
+	}
+
+	nt := &v1alpha1.ExtensionResourceDefinition{}
+	if err := json.Unmarshal(respBody, nt); err != nil {
+		return nil, err
+	}
+
+	return nt, nil
+}
+
+// ExtensionResourceDefinitions list all ERDs
+func (c *Client) ExtensionResourceDefinitions(
+	ctx context.Context, extensionIDOrSlug string, deleted bool,
+) ([]*v1alpha1.ExtensionResourceDefinition, error) {
+	if extensionIDOrSlug == "" {
+		return nil, ErrMissingExtensionIDOrSlug
+	}
+
+	u := fmt.Sprintf(
+		"%s/api/%s/extensions/%s/erds",
+		c.url,
+		governorAPIVersionAlpha,
+		extensionIDOrSlug,
+	)
+	if deleted {
+		u += "?deleted"
+	}
+
+	req, err := c.newGovernorRequest(ctx, http.MethodGet, u)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, v1alpha1.ErrExtensionNotFound
+	}
+
+	if resp.StatusCode != http.StatusOK &&
+		resp.StatusCode != http.StatusAccepted &&
+		resp.StatusCode != http.StatusNoContent {
+		return nil, ErrRequestNonSuccess
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	erds := []*v1alpha1.ExtensionResourceDefinition{}
+	if err := json.Unmarshal(respBody, &erds); err != nil {
+		return nil, err
+	}
+
+	return erds, nil
+}
+
+// CreateExtensionResourceDefinition creates an ERD
+func (c *Client) CreateExtensionResourceDefinition(
+	ctx context.Context, extensionIDOrSlug string, erdReq *v1alpha1.ExtensionResourceDefinitionReq,
+) (*v1alpha1.ExtensionResourceDefinition, error) {
+	if extensionIDOrSlug == "" {
+		return nil, ErrMissingExtensionIDOrSlug
+	}
+
+	req, err := c.newGovernorRequest(
+		ctx, http.MethodPost,
+		fmt.Sprintf(
+			"%s/api/%s/extensions/%s/erds",
+			c.url, governorAPIVersionAlpha, extensionIDOrSlug,
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	erdReqJSON, err := json.Marshal(erdReq)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Body = io.NopCloser(bytes.NewReader(erdReqJSON))
+
+	resp, err := c.httpClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, v1alpha1.ErrExtensionNotFound
+	}
+
+	if resp.StatusCode != http.StatusOK &&
+		resp.StatusCode != http.StatusAccepted &&
+		resp.StatusCode != http.StatusNoContent {
+		return nil, ErrRequestNonSuccess
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	erd := &v1alpha1.ExtensionResourceDefinition{}
+	if err := json.Unmarshal(respBody, erd); err != nil {
+		return nil, err
+	}
+
+	return erd, nil
+}
+
+// UpdateExtensionResourceDefinition updates an ERD, erd version must be provided
+// when using erd slug
+func (c *Client) UpdateExtensionResourceDefinition(
+	ctx context.Context, extensionIDOrSlug, erdIDOrSlug, erdVersion string, erdReq *v1alpha1.ExtensionResourceDefinitionReq,
+) (*v1alpha1.ExtensionResourceDefinition, error) {
+	if extensionIDOrSlug == "" {
+		return nil, ErrMissingExtensionIDOrSlug
+	}
+
+	if erdIDOrSlug == "" {
+		return nil, ErrMissingERDID
+	}
+
+	u := fmt.Sprintf(
+		"%s/api/%s/extensions/%s/erds/%s",
+		c.url,
+		governorAPIVersionAlpha,
+		extensionIDOrSlug,
+		erdIDOrSlug,
+	)
+	if erdVersion != "" {
+		u += fmt.Sprintf("/%s", erdVersion)
+	}
+
+	req, err := c.newGovernorRequest(ctx, http.MethodPatch, u)
+	if err != nil {
+		return nil, err
+	}
+
+	erdReqJSON, err := json.Marshal(erdReq)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Body = io.NopCloser(bytes.NewReader(erdReqJSON))
+
+	resp, err := c.httpClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, handleERDStatusNotFound(respBody)
+	}
+
+	if resp.StatusCode != http.StatusOK &&
+		resp.StatusCode != http.StatusAccepted &&
+		resp.StatusCode != http.StatusNoContent {
+		return nil, ErrRequestNonSuccess
+	}
+
+	erd := &v1alpha1.ExtensionResourceDefinition{}
+	if err := json.Unmarshal(respBody, erd); err != nil {
+		return nil, err
+	}
+
+	return erd, nil
+}
+
+// DeleteExtensionResourceDefinition deletes a extension, erd version must be provided
+// when using erd slug
+func (c *Client) DeleteExtensionResourceDefinition(
+	ctx context.Context, extensionIDOrSlug, erdIDOrSlug, erdVersion string,
+) error {
+	if extensionIDOrSlug == "" {
+		return ErrMissingExtensionIDOrSlug
+	}
+
+	if erdIDOrSlug == "" {
+		return ErrMissingERDID
+	}
+
+	u := fmt.Sprintf(
+		"%s/api/%s/extensions/%s/erds/%s",
+		c.url,
+		governorAPIVersionAlpha,
+		extensionIDOrSlug,
+		erdIDOrSlug,
+	)
+	if erdVersion != "" {
+		u += fmt.Sprintf("/%s", erdVersion)
+	}
+
+	req, err := c.newGovernorRequest(ctx, http.MethodDelete, u)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.httpClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return handleERDStatusNotFound(respBody)
+	}
+
+	if resp.StatusCode != http.StatusOK &&
+		resp.StatusCode != http.StatusAccepted &&
+		resp.StatusCode != http.StatusNoContent {
+		return ErrRequestNonSuccess
+	}
+
+	return nil
+}

--- a/pkg/client/extension_resource_definitions_test.go
+++ b/pkg/client/extension_resource_definitions_test.go
@@ -1,0 +1,865 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/metal-toolbox/governor-api/pkg/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+)
+
+const (
+	testERDsResponse = `[
+		{
+			"id": "a82a34a5-db1f-464f-af9c-76086e79f715",
+			"name": "ERD 1",
+			"description": "some description",
+			"enabled": true,
+			"slug_singular": "erd-1",
+			"slug_plural": "erd-1s",
+			"version": "v1alpha1",
+			"scope": "system",
+			"schema": {
+				"hello": "world"
+			},
+			"created_at": "2023-09-27T16:52:45.244555Z",
+			"updated_at": "2023-09-27T16:52:45.244555Z",
+			"deleted_at": null,
+			"extension_id": "9ee302b2-e559-4553-a5ab-0a06484ad883"
+		},
+		{
+			"id": "a82a34a5-db1f-464f-af9c-76086e79f715",
+			"name": "ERD 2",
+			"description": "some description",
+			"enabled": true,
+			"slug_singular": "erd-2",
+			"slug_plural": "erd-2s",
+			"version": "v1alpha1",
+			"scope": "user",
+			"schema": {
+				"hello": "world"
+			},
+			"created_at": "2023-09-27T16:52:45.244555Z",
+			"updated_at": "2023-09-27T16:52:45.244555Z",
+			"deleted_at": null,
+			"extension_id": "9ee302b2-e559-4553-a5ab-0a06484ad883"
+		}
+	]`
+
+	testERDResponse = `{
+		"id": "a82a34a5-db1f-464f-af9c-76086e79f715",
+		"name": "ERD 1",
+		"description": "some description",
+		"enabled": true,
+		"slug_singular": "erd-1",
+		"slug_plural": "erd-1s",
+		"version": "v1alpha1",
+		"scope": "system",
+		"schema": {
+			"hello": "world"
+		},
+		"created_at": "2023-09-27T16:52:45.244555Z",
+		"updated_at": "2023-09-27T16:52:45.244555Z",
+		"deleted_at": null,
+		"extension_id": "9ee302b2-e559-4553-a5ab-0a06484ad883"
+	}`
+)
+
+func TestClient_ExtensionResourceDefinitions(t *testing.T) {
+	testResp := func(r []byte) []*v1alpha1.ExtensionResourceDefinition {
+		resp := []*v1alpha1.ExtensionResourceDefinition{}
+		if err := json.Unmarshal(r, &resp); err != nil {
+			t.Error(err)
+		}
+
+		return resp
+	}
+
+	type fields struct {
+		httpClient HTTPDoer
+	}
+
+	tests := []struct {
+		name        string
+		fields      fields
+		expected    []*v1alpha1.ExtensionResourceDefinition
+		expectErr   bool
+		expectedErr error
+	}{
+		{
+			name: "example request",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(testERDsResponse),
+					statusCode: http.StatusOK,
+				},
+			},
+			expected:  testResp([]byte(testERDsResponse)),
+			expectErr: false,
+		},
+		{
+			name: "non-success",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusInternalServerError,
+				},
+			},
+			expectErr:   true,
+			expectedErr: ErrRequestNonSuccess,
+		},
+		{
+			name: "bad json response",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusOK,
+					resp:       []byte(`{`),
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "null response",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusOK,
+					resp:       []byte(`null`),
+				},
+			},
+			expected:  []*v1alpha1.ExtensionResourceDefinition(nil),
+			expectErr: false,
+		},
+		{
+			name: "extension not found",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusNotFound,
+					resp:       []byte(`{"error":"extension not found: sql: no rows in result set"}`),
+				},
+			},
+			expected:    []*v1alpha1.ExtensionResourceDefinition(nil),
+			expectErr:   true,
+			expectedErr: v1alpha1.ErrExtensionNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				url:                    "https://the.gov",
+				logger:                 zap.NewNop(),
+				httpClient:             tt.fields.httpClient,
+				clientCredentialConfig: &mockTokener{t: t},
+				token:                  &oauth2.Token{AccessToken: "topSekret"},
+			}
+			got, err := c.ExtensionResourceDefinitions(context.TODO(), "test-extension-1", false)
+
+			if tt.expectedErr != nil {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+				return
+			} else if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestClient_ExtensionResourceDefinition(t *testing.T) {
+	testResp := func(r []byte) *v1alpha1.ExtensionResourceDefinition {
+		resp := &v1alpha1.ExtensionResourceDefinition{}
+		if err := json.Unmarshal(r, resp); err != nil {
+			t.Error(err)
+		}
+
+		return resp
+	}
+
+	type fields struct {
+		httpClient *mockHTTPDoer
+	}
+
+	tests := []struct {
+		name         string
+		extensionID  string
+		erdID        string
+		erdVersion   string
+		fields       fields
+		expected     *v1alpha1.ExtensionResourceDefinition
+		expectedErr  error
+		expectedPath string
+		expectErr    bool
+	}{
+		{
+			name:        "request with slug",
+			extensionID: "test-extension-1",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(testERDResponse),
+					statusCode: http.StatusOK,
+				},
+			},
+			expected:     testResp([]byte(testERDResponse)),
+			expectedPath: "/api/v1alpha1/extensions/test-extension-1/erds/erd-1/v1alpha1",
+			expectErr:    false,
+		},
+		{
+			name:        "request with uuid",
+			extensionID: "test-extension-1",
+			erdID:       "a82a34a5-db1f-464f-af9c-76086e79f715",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(testERDResponse),
+					statusCode: http.StatusOK,
+				},
+			},
+			expected:     testResp([]byte(testERDResponse)),
+			expectedPath: "/api/v1alpha1/extensions/test-extension-1/erds/a82a34a5-db1f-464f-af9c-76086e79f715",
+			expectErr:    false,
+		},
+		{
+			name:        "non-success",
+			extensionID: "test-extension-1",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusInternalServerError,
+				},
+			},
+			expectErr:   true,
+			expectedErr: ErrRequestNonSuccess,
+		},
+		{
+			name:        "bad json response",
+			extensionID: "test-extension-1",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusOK,
+					resp:       []byte(`{`),
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:        "missing extension id",
+			extensionID: "",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusOK,
+				},
+			},
+			expectErr:   true,
+			expectedErr: ErrMissingExtensionIDOrSlug,
+		},
+		{
+			name:        "missing ERD id",
+			extensionID: "test-extension-1",
+			erdID:       "",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusOK,
+				},
+			},
+			expectErr:   true,
+			expectedErr: ErrMissingERDID,
+		},
+		{
+			name:        "extension not found",
+			extensionID: "test-extension-1",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusNotFound,
+					resp:       []byte(`{"error":"extension does not exist"}`),
+				},
+			},
+			expectErr:   true,
+			expectedErr: v1alpha1.ErrExtensionNotFound,
+		},
+		{
+			name:        "ERD not found",
+			extensionID: "test-extension-1",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusNotFound,
+					resp:       []byte(`{"error":"ERD does not exist"}`),
+				},
+			},
+			expectErr:   true,
+			expectedErr: v1alpha1.ErrERDNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				url:                    "https://the.gov",
+				logger:                 zap.NewNop(),
+				httpClient:             tt.fields.httpClient,
+				clientCredentialConfig: &mockTokener{t: t},
+				token:                  &oauth2.Token{AccessToken: "topSekret"},
+			}
+			got, err := c.ExtensionResourceDefinition(context.TODO(), tt.extensionID, tt.erdID, tt.erdVersion, false)
+
+			if tt.expectedErr != nil {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+				return
+			} else if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+
+			if tt.expectedPath != "" {
+				assert.Equal(t, tt.expectedPath, tt.fields.httpClient.Request().URL.Path)
+			}
+		})
+	}
+}
+
+func TestClient_CreateExtensionResourceDefinition(t *testing.T) {
+	testResp := func(r []byte) *v1alpha1.ExtensionResourceDefinition {
+		resp := &v1alpha1.ExtensionResourceDefinition{}
+		if err := json.Unmarshal(r, resp); err != nil {
+			t.Error(err)
+		}
+
+		return resp
+	}
+
+	enabled := true
+
+	type fields struct {
+		httpClient HTTPDoer
+	}
+
+	tests := []struct {
+		name        string
+		extensionID string
+		fields      fields
+		req         *v1alpha1.ExtensionResourceDefinitionReq
+		expected    *v1alpha1.ExtensionResourceDefinition
+		expectedErr error
+		expectErr   bool
+	}{
+		{
+			name:        "example request",
+			extensionID: "test-extension-1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(testERDResponse),
+					statusCode: http.StatusOK,
+				},
+			},
+			req: &v1alpha1.ExtensionResourceDefinitionReq{
+				Name:         "ERD 1",
+				Description:  "some description",
+				Enabled:      &enabled,
+				SlugSingular: "erd-1",
+				SlugPlural:   "erd-1s",
+				Version:      "v1alpha1",
+				Scope:        "system",
+				Schema:       []byte(`{"hello": "world"}`),
+			},
+			expected:  testResp([]byte(testERDResponse)),
+			expectErr: false,
+		},
+		{
+			name:        "example request status accepted",
+			extensionID: "test-extension-1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(testERDResponse),
+					statusCode: http.StatusAccepted,
+				},
+			},
+			req: &v1alpha1.ExtensionResourceDefinitionReq{
+				Name:         "ERD 1",
+				Description:  "some description",
+				Enabled:      &enabled,
+				SlugSingular: "erd-1",
+				SlugPlural:   "erd-1s",
+				Version:      "v1alpha1",
+				Scope:        "system",
+				Schema:       []byte(`{"hello": "world"}`),
+			},
+			expected:  testResp([]byte(testERDResponse)),
+			expectErr: false,
+		},
+		{
+			name:        "non-success",
+			extensionID: "test-extension-1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusInternalServerError,
+				},
+			},
+			req:         &v1alpha1.ExtensionResourceDefinitionReq{},
+			expectErr:   true,
+			expectedErr: ErrRequestNonSuccess,
+		},
+		{
+			name:        "bad json response",
+			extensionID: "test-extension-1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusOK,
+					resp:       []byte(`{`),
+				},
+			},
+			req:       &v1alpha1.ExtensionResourceDefinitionReq{},
+			expectErr: true,
+		},
+		{
+			name:        "extension ID missing",
+			extensionID: "",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(testERDResponse),
+					statusCode: http.StatusOK,
+				},
+			},
+			req:         &v1alpha1.ExtensionResourceDefinitionReq{},
+			expectErr:   true,
+			expectedErr: ErrMissingExtensionIDOrSlug,
+		},
+		{
+			name:        "extension not found",
+			extensionID: "test-extension-1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(`{"error":"extension not found: sql: no rows in result set"}`),
+					statusCode: http.StatusNotFound,
+				},
+			},
+			req:         &v1alpha1.ExtensionResourceDefinitionReq{},
+			expectErr:   true,
+			expectedErr: v1alpha1.ErrExtensionNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				url:                    "https://the.gov/",
+				logger:                 zap.NewNop(),
+				httpClient:             tt.fields.httpClient,
+				clientCredentialConfig: &mockTokener{t: t},
+				token:                  &oauth2.Token{AccessToken: "topSekret"},
+			}
+			got, err := c.CreateExtensionResourceDefinition(context.TODO(), tt.extensionID, tt.req)
+
+			if tt.expectedErr != nil {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+				return
+			} else if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestClient_UpdateExtensionResourceDefinition(t *testing.T) {
+	testResp := func(r []byte) *v1alpha1.ExtensionResourceDefinition {
+		resp := &v1alpha1.ExtensionResourceDefinition{}
+		if err := json.Unmarshal(r, resp); err != nil {
+			t.Error(err)
+		}
+
+		return resp
+	}
+
+	type fields struct {
+		httpClient *mockHTTPDoer
+	}
+
+	tests := []struct {
+		name         string
+		extensionID  string
+		erdID        string
+		erdVersion   string
+		fields       fields
+		id           string
+		req          *v1alpha1.ExtensionResourceDefinitionReq
+		expected     *v1alpha1.ExtensionResourceDefinition
+		expectedErr  error
+		expectErr    bool
+		expectedPath string
+	}{
+		{
+			name:        "example request with slug",
+			extensionID: "test-extension-1",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(testERDResponse),
+					statusCode: http.StatusOK,
+				},
+			},
+			req: &v1alpha1.ExtensionResourceDefinitionReq{
+				Description: "some test",
+			},
+			expected:     testResp([]byte(testERDResponse)),
+			expectedPath: "/api/v1alpha1/extensions/test-extension-1/erds/erd-1/v1alpha1",
+			expectErr:    false,
+		},
+		{
+			name:        "example request with id",
+			extensionID: "test-extension-1",
+			erdID:       "a82a34a5-db1f-464f-af9c-76086e79f715",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(testERDResponse),
+					statusCode: http.StatusOK,
+				},
+			},
+			req: &v1alpha1.ExtensionResourceDefinitionReq{
+				Description: "some test",
+			},
+			expected:     testResp([]byte(testERDResponse)),
+			expectedPath: "/api/v1alpha1/extensions/test-extension-1/erds/a82a34a5-db1f-464f-af9c-76086e79f715",
+			expectErr:    false,
+		},
+		{
+			name:        "example request status accepted",
+			extensionID: "test-extension-1",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(testERDResponse),
+					statusCode: http.StatusAccepted,
+				},
+			},
+			id: "test-extension-1",
+			req: &v1alpha1.ExtensionResourceDefinitionReq{
+				Description: "some test",
+			},
+			expected:  testResp([]byte(testERDResponse)),
+			expectErr: false,
+		},
+		{
+			name:        "non-success",
+			extensionID: "test-extension-1",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusInternalServerError,
+				},
+			},
+			id: "test-extension-1",
+			req: &v1alpha1.ExtensionResourceDefinitionReq{
+				Description: "some test",
+			},
+			expectErr:   true,
+			expectedErr: ErrRequestNonSuccess,
+		},
+		{
+			name:        "bad json response",
+			extensionID: "test-extension-1",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusOK,
+					resp:       []byte(`{`),
+				},
+			},
+			id: "test-extension-1",
+			req: &v1alpha1.ExtensionResourceDefinitionReq{
+				Description: "some test",
+			},
+			expectErr: true,
+		},
+		{
+			name:       "missing extension id",
+			erdID:      "erd-1",
+			erdVersion: "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(""),
+					statusCode: http.StatusOK,
+				},
+			},
+			req: &v1alpha1.ExtensionResourceDefinitionReq{
+				Description: "some test",
+			},
+			expectErr:   true,
+			expectedErr: ErrMissingExtensionIDOrSlug,
+		},
+		{
+			name:        "missing erd id",
+			extensionID: "test-extension-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(""),
+					statusCode: http.StatusOK,
+				},
+			},
+			req: &v1alpha1.ExtensionResourceDefinitionReq{
+				Description: "some test",
+			},
+			expectErr:   true,
+			expectedErr: ErrMissingERDID,
+		},
+		{
+			name:        "extension not found",
+			extensionID: "test-extension-1",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(`{"error":"extension does not exist"}`),
+					statusCode: http.StatusNotFound,
+				},
+			},
+			req: &v1alpha1.ExtensionResourceDefinitionReq{
+				Description: "some test",
+			},
+			expectErr:   true,
+			expectedErr: v1alpha1.ErrExtensionNotFound,
+		},
+		{
+			name:        "ERD not found",
+			extensionID: "test-extension-1",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(`{"error":"ERD does not exist"}`),
+					statusCode: http.StatusNotFound,
+				},
+			},
+			req: &v1alpha1.ExtensionResourceDefinitionReq{
+				Description: "some test",
+			},
+			expectErr:   true,
+			expectedErr: v1alpha1.ErrERDNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				url:                    "https://the.gov",
+				logger:                 zap.NewNop(),
+				httpClient:             tt.fields.httpClient,
+				clientCredentialConfig: &mockTokener{t: t},
+				token:                  &oauth2.Token{AccessToken: "topSekret"},
+			}
+			got, err := c.UpdateExtensionResourceDefinition(context.TODO(), tt.extensionID, tt.erdID, tt.erdVersion, tt.req)
+
+			if tt.expectedErr != nil {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+				return
+			} else if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+
+			if tt.expectedPath != "" {
+				assert.Equal(t, tt.expectedPath, tt.fields.httpClient.Request().URL.Path)
+			}
+		})
+	}
+}
+
+func TestClient_DeleteExtensionResourceDefinition(t *testing.T) {
+	type fields struct {
+		httpClient *mockHTTPDoer
+	}
+
+	tests := []struct {
+		name         string
+		extensionID  string
+		erdID        string
+		erdVersion   string
+		fields       fields
+		expectedPath string
+		expectedErr  error
+		expectErr    bool
+	}{
+		{
+			name:        "example request with slug",
+			extensionID: "test-extension-1",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(testERDResponse),
+					statusCode: http.StatusOK,
+				},
+			},
+			expectErr:    false,
+			expectedPath: "/api/v1alpha1/extensions/test-extension-1/erds/erd-1/v1alpha1",
+		},
+		{
+			name:        "example request with id",
+			extensionID: "test-extension-1",
+			erdID:       "a82a34a5-db1f-464f-af9c-76086e79f715",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					resp:       []byte(testERDResponse),
+					statusCode: http.StatusOK,
+				},
+			},
+			expectErr:    false,
+			expectedPath: "/api/v1alpha1/extensions/test-extension-1/erds/a82a34a5-db1f-464f-af9c-76086e79f715",
+		},
+		{
+			name:        "non-success",
+			extensionID: "test-extension-1",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusInternalServerError,
+				},
+			},
+			expectErr:   true,
+			expectedErr: ErrRequestNonSuccess,
+		},
+		{
+			name:       "missing extension id",
+			erdID:      "erd-1",
+			erdVersion: "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusOK,
+				},
+			},
+			expectErr:   true,
+			expectedErr: ErrMissingExtensionIDOrSlug,
+		},
+		{
+			name:        "missing ERD id",
+			extensionID: "test-extension-1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusOK,
+				},
+			},
+			expectErr:   true,
+			expectedErr: ErrMissingERDID,
+		},
+		{
+			name:        "extension not found",
+			extensionID: "test-extension-1",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusNotFound,
+					resp:       []byte(`{"error":"extension does not exist"}`),
+				},
+			},
+			expectErr:   true,
+			expectedErr: v1alpha1.ErrExtensionNotFound,
+		},
+		{
+			name:        "ERD not found",
+			extensionID: "test-extension-1",
+			erdID:       "erd-1",
+			erdVersion:  "v1alpha1",
+			fields: fields{
+				httpClient: &mockHTTPDoer{
+					t:          t,
+					statusCode: http.StatusNotFound,
+					resp:       []byte(`{"error":"ERD does not exist"}`),
+				},
+			},
+			expectErr:   true,
+			expectedErr: v1alpha1.ErrERDNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				url:                    "https://the.gov",
+				logger:                 zap.NewNop(),
+				httpClient:             tt.fields.httpClient,
+				clientCredentialConfig: &mockTokener{t: t},
+				token:                  &oauth2.Token{AccessToken: "topSekret"},
+			}
+			err := c.DeleteExtensionResourceDefinition(context.TODO(), tt.extensionID, tt.erdID, tt.erdVersion)
+
+			if tt.expectedErr != nil {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+				return
+			} else if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			if tt.expectedPath != "" {
+				assert.Equal(t, tt.expectedPath, tt.fields.httpClient.Request().URL.Path)
+			}
+		})
+	}
+}

--- a/pkg/client/extension_resource_definitions_test.go
+++ b/pkg/client/extension_resource_definitions_test.go
@@ -286,7 +286,7 @@ func TestClient_ExtensionResourceDefinition(t *testing.T) {
 				},
 			},
 			expectErr:   true,
-			expectedErr: ErrMissingERDID,
+			expectedErr: ErrMissingERDIDOrSlug,
 		},
 		{
 			name:        "extension not found",
@@ -652,7 +652,7 @@ func TestClient_UpdateExtensionResourceDefinition(t *testing.T) {
 				Description: "some test",
 			},
 			expectErr:   true,
-			expectedErr: ErrMissingERDID,
+			expectedErr: ErrMissingERDIDOrSlug,
 		},
 		{
 			name:        "extension not found",
@@ -802,7 +802,7 @@ func TestClient_DeleteExtensionResourceDefinition(t *testing.T) {
 				},
 			},
 			expectErr:   true,
-			expectedErr: ErrMissingERDID,
+			expectedErr: ErrMissingERDIDOrSlug,
 		},
 		{
 			name:        "extension not found",

--- a/pkg/client/governor_test.go
+++ b/pkg/client/governor_test.go
@@ -21,6 +21,7 @@ type mockHTTPDoer struct {
 	t          *testing.T
 	statusCode int
 	resp       []byte
+	request    *http.Request
 }
 
 type mockTokener struct {
@@ -29,14 +30,19 @@ type mockTokener struct {
 	token *oauth2.Token
 }
 
-func (m *mockHTTPDoer) Do(_ *http.Request) (*http.Response, error) {
+func (m *mockHTTPDoer) Do(r *http.Request) (*http.Response, error) {
 	resp := http.Response{
 		StatusCode: m.statusCode,
 	}
 
+	m.request = r
 	resp.Body = io.NopCloser(bytes.NewReader(m.resp))
 
 	return &resp, nil
+}
+
+func (m *mockHTTPDoer) Request() *http.Request {
+	return m.request
 }
 
 func (m *mockTokener) Token(_ context.Context) (*oauth2.Token, error) {

--- a/pkg/events/v1alpha1/events.go
+++ b/pkg/events/v1alpha1/events.go
@@ -41,6 +41,8 @@ const (
 	GovernorNotificationTargetsEventSubject = "notification.targets"
 	// GovernorExtensionsEventSubject is the subject name for extensions events (minus the subject prefix)
 	GovernorExtensionsEventSubject = "extensions"
+	// GovernorExtensionResourceDefinitionsEventSubject is the subject name for extensions resource definition events (minus the subject prefix)
+	GovernorExtensionResourceDefinitionsEventSubject = "extension.erds"
 )
 
 // Event is an event notification from Governor.


### PR DESCRIPTION


Operation | Method | URI
-- | -- | --
list | GET | /api/v1alpha1/extensions/:extension-slug-or-id/erds
create | POST | /api/v1alpha1/extensions/:extension-slug-or-id/erds
get by ID | GET | /api/v1alpha1/extensions/:extension-slug-or-id/erds/:uuid
get by slug | GET | /api/v1alpha1/extensions/:extension-slug-or-id/erds/:slug-singular/:version
update by ID | PATCH | /api/v1alpha1/extensions/:extension-slug-or-id/erds/:uuid
update by slug | PATCH | /api/v1alpha1/extensions/:extension-slug-or-id/erds/:slug-singular/:version
delete by ID | DELETE | /api/v1alpha1/extensions/:extension-slug-or-id/erds/:uuid
delete by slug | DELETE | /api/v1alpha1/extensions/:extension-slug-or-id/erds/:slug-singular/:version

