### PR TITLE
[Small Fix] Enhance JSON Validator Error Messages

### DIFF
--- a/pkg/jsonschema/compiler_test.go
+++ b/pkg/jsonschema/compiler_test.go
@@ -1,0 +1,108 @@
+package jsonschema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type CompilerTestSuite struct {
+	suite.Suite
+}
+
+func (s *CompilerTestSuite) TestCompile() {
+	tests := []struct {
+		name          string
+		expectedErr   string
+		erdSlugPlural string
+		erdVersion    string
+		schema        string
+	}{
+		{
+			name: "ok",
+			schema: `{
+				"$id": "v1.canada-geese.test-ex-1",
+				"$schema": "https://json-schema.org/draft/2020-12/schema",
+				"title": "Canada Goose",
+				"type": "object",
+				"unique": [
+					"firstName",
+					"lastName"
+				],
+				"required": [
+					"firstName",
+					"lastName"
+				],
+				"properties": {
+					"firstName": {
+						"type": "string",
+						"description": "The goose's first name.",
+						"ui": {
+							"hide": true
+						}
+					},
+					"lastName": {
+						"type": "string",
+						"description": "The goose's last name."
+					},
+					"age": {
+						"description": "Age in years which must be equal to or greater than zero.",
+						"type": "integer",
+						"minimum": 0
+					}
+				}
+			}`,
+			expectedErr:   "",
+			erdSlugPlural: "canada-geese",
+			erdVersion:    "v1alpha1",
+		},
+		{
+			name: "test schema with required missing",
+			schema: `
+			{
+				"$id": "v1.hello-world.extension-example.governor.equinixmetal.com",
+				"$schema": "https://json-schema.org/draft/2020-12/schema",
+				"unique": [
+					"name"
+				],
+				"properties": {
+					"name": {
+						"default": "world",
+						"description": "hello, name",
+						"type": "string"
+					}
+				},
+				"title": "Greeting",
+				"type": "object"
+			}
+			`,
+			expectedErr:   `cannot apply unique constraint when "required" is not provided`,
+			erdSlugPlural: "greetings",
+			erdVersion:    "v1alpha1",
+		},
+	}
+
+	for _, tt := range tests {
+		compiler := NewCompiler(
+			"extension-validator", tt.erdSlugPlural, tt.erdVersion,
+			WithUniqueConstraint(
+				context.Background(),
+				nil, nil, nil,
+			),
+		)
+
+		_, err := compiler.Compile(tt.schema)
+
+		if tt.expectedErr != "" {
+			s.Require().Error(err)
+			s.Require().Contains(err.Error(), tt.expectedErr)
+		} else {
+			s.Require().NoError(err)
+		}
+	}
+}
+
+func TestCompilerSuite(t *testing.T) {
+	suite.Run(t, new(CompilerTestSuite))
+}

--- a/pkg/jsonschema/unique_constraint.go
+++ b/pkg/jsonschema/unique_constraint.go
@@ -131,7 +131,15 @@ func (uc *UniqueConstraintCompiler) Compile(
 		return nil, nil
 	}
 
-	requiredFields, err := assertStringSlice(m["required"])
+	required, ok := m["required"]
+	if !ok {
+		return nil, fmt.Errorf(
+			`%w: cannot apply unique constraint when "required" is not provided`,
+			ErrInvalidUniqueProperty,
+		)
+	}
+
+	requiredFields, err := assertStringSlice(required)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/jsonschema/unique_constraint_test.go
+++ b/pkg/jsonschema/unique_constraint_test.go
@@ -95,6 +95,13 @@ func (s *UniqueConstrainTestSuite) TestCompile() {
 			expectedErr: "",
 		},
 		{
+			name: "unique exists but required missing",
+			inputMap: map[string]interface{}{
+				"unique": []interface{}{"a"},
+			},
+			expectedErr: `cannot apply unique constraint when "required" is not provided`,
+		},
+		{
 			name: "unique exists but required invalid",
 			inputMap: map[string]interface{}{
 				"unique":   []interface{}{"a"},


### PR DESCRIPTION
An incorrect error message was returned in the `jsonvalidator` when `unique` is defined but `required` is missing