### PR TITLE
Add cosign steps in goreleaser configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: goreleaser
 
-on: push
+on:
+  push:
+    tags:
+      - 'v*.*.*'
 
 jobs:
   goreleaser:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: goreleaser
 
-on:
-  push:
-    tags:
-      - 'v*.*.*'
+on: push
 
 jobs:
   goreleaser:
@@ -43,5 +40,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COSIGN_EXPERIMENTAL: 1
           GOVERSION: "1.20"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,3 +54,32 @@ release:
   name_template: "Release {{.Tag}}"
   header: |
     # What's Changed
+
+sboms:
+  - artifacts: archive
+  - id: source
+    artifacts: source
+
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - "sign-blob"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes" # required on cosign 2.0.0+
+    artifacts: all
+    output: true
+
+docker_signs:
+  - cmd: cosign
+    args:
+      - "sign"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      - "${artifact}"
+      - "--yes" # required on cosign 2.0.0+
+    artifacts: all
+    output: true


### PR DESCRIPTION
This commit adds cosign to the goreleaser. The change will generate SBOM for governor-api and sign them using cosign, including the docker image.

cosign is an open-source tool developed by Chainguard that signs container images, allowing other users to cryptographically verify the origin of container images. [1]

cosign has different operating modes. This commit utilizes Chainguard's signing infrastructure via "keyless signing". [2] Keyless signing makes image signing easy for open-source projects because Chainguard operates the signing infrastructure on behalf of others.

Note: This commit is based on work by Chris Nesbitt-Smith, who published an example GitHub Actions workflow for running cosign. [3]

References

    https://docs.sigstore.dev/signing/quickstart
    https://edu.chainguard.dev/open-source/sigstore/cosign/an-introduction-to-cosign/#keyless-signing
    https://github.com/chrisns/cosign-keyless-demo/blob/f35f6c776f/.github/workflows/ci.yml

