### PR TITLE
DevContainer QoL change

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,7 @@
 		}
 	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [3001],
+	// "forwardPorts": [3001],
 	// Uncomment the next line if you want start specific services in your Docker Compose config.
 	// "runServices": [],
 	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: "3.9"
 
 volumes:
   crdb-data:
@@ -11,7 +11,6 @@ volumes:
 networks:
   governor:
 
-
 services:
   devcontainer:
     build:
@@ -20,6 +19,8 @@ services:
     depends_on:
       - nats
     command: sleep infinity
+    ports:
+      - "3001:3001"
     env_file:
       - .env
     volumes:
@@ -112,7 +113,7 @@ services:
       - nats-init
     command:
       - -c
-      - '/etc/nats/nats-server.conf'
+      - "/etc/nats/nats-server.conf"
       - -D
     volumes:
       - ./nats:/etc/nats


### PR DESCRIPTION
We pass several ports from this devcontainer compose stack (NATS, Hydra, CRDB...) through to the host using the `ports` option directly in the `docker-compose.yml` file... but we have been omitting the port used by the governor-api app itself from the compose file and instead forwarded it using the `devcontainer.json` `forwardPorts` definition.

This works seamlessly in VSCode, however, `forwardPorts` is unsupported by the devcontainer CLI for anyone using another editor/IDE. The main difference between forwarding a port in the compose file vs. using `forwardPorts` is that `forwardPorts` is necessary for services that only listen on 127.0.0.1 - however, this service listens on 0.0.0.0, thus there is no functional difference here, so proposing this change for QoL/compatibility reasons.