### PR TITLE
Add Content Assertions for JSON Schema Compiler

### DIFF
--- a/pkg/jsonschema/compiler.go
+++ b/pkg/jsonschema/compiler.go
@@ -28,6 +28,8 @@ func NewCompiler(
 	opts ...Option,
 ) *Compiler {
 	c := &Compiler{*jsonschema.NewCompiler(), extensionID, slugPlural, version}
+	c.Compiler.AssertFormat = true
+	c.Compiler.AssertContent = true
 
 	for _, opt := range opts {
 		opt(c)


### PR DESCRIPTION
Enable content assertion and format assertion for the JSON schema compiler, such that all json payload will be validated properly against the schema.