### PR TITLE
Extension resource lifecycle

### DIFF
--- a/pkg/api/v1alpha1/extension_lifecycle.go
+++ b/pkg/api/v1alpha1/extension_lifecycle.go
@@ -1,0 +1,55 @@
+package v1alpha1
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/metal-toolbox/governor-api/internal/models"
+	"github.com/volatiletech/sqlboiler/v4/queries/qm"
+	"go.uber.org/zap"
+)
+
+func (r *Router) mwExtensionEnabledCheck(c *gin.Context) {
+	extensionIDOrSlug := c.Param("eid")
+	if extensionIDOrSlug == "" {
+		extensionIDOrSlug = c.Param("ex-slug")
+	}
+
+	erdQMs := []qm.QueryMod{
+		qm.OrderBy("name"),
+	}
+
+	var extensionQM qm.QueryMod
+
+	if _, err := uuid.Parse(extensionIDOrSlug); err != nil {
+		extensionQM = qm.Where("slug = ?", extensionIDOrSlug)
+	} else {
+		extensionQM = qm.Where("id = ?", extensionIDOrSlug)
+	}
+
+	r.Logger.Debug("mwExtensionEnabledCheck", zap.String("extension-id-slug", extensionIDOrSlug))
+
+	extension, err := models.Extensions(
+		extensionQM, qm.Load(
+			models.ExtensionRels.ExtensionResourceDefinitions,
+			erdQMs...,
+		),
+	).One(c.Request.Context(), r.DB)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			sendError(c, http.StatusNotFound, "extension not found or deleted: "+err.Error())
+			return
+		}
+
+		sendError(c, http.StatusInternalServerError, "error getting extension"+err.Error())
+
+		return
+	}
+
+	if !extension.Enabled {
+		sendError(c, http.StatusBadRequest, "extension is disabled")
+	}
+}

--- a/pkg/api/v1alpha1/router.go
+++ b/pkg/api/v1alpha1/router.go
@@ -621,7 +621,6 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("CreateExtensionResourceDefinition"),
 		r.AuthMW.AuthRequired(createScopesWithOpenID("governor:extensions")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
-		r.mwExtensionEnabledCheck,
 		r.createExtensionResourceDefinition,
 	)
 
@@ -644,7 +643,6 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("UpdateExtensionResourceDefinitionByID"),
 		r.AuthMW.AuthRequired(updateScopesWithOpenID("governor:extensions")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
-		r.mwExtensionEnabledCheck,
 		r.updateExtensionResourceDefinition,
 	)
 
@@ -653,7 +651,6 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("UpdateExtensionResourceDefinitionBySlug"),
 		r.AuthMW.AuthRequired(updateScopesWithOpenID("governor:extensions")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
-		r.mwExtensionEnabledCheck,
 		r.updateExtensionResourceDefinition,
 	)
 
@@ -662,7 +659,6 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("DeleteExtensionResourceDefinitionByID"),
 		r.AuthMW.AuthRequired(deleteScopesWithOpenID("governor:extensions")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
-		r.mwExtensionEnabledCheck,
 		r.deleteExtensionResourceDefinition,
 	)
 
@@ -671,7 +667,6 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("DeleteExtensionResourceDefinitionBySlug"),
 		r.AuthMW.AuthRequired(deleteScopesWithOpenID("governor:extensions")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
-		r.mwExtensionEnabledCheck,
 		r.deleteExtensionResourceDefinition,
 	)
 

--- a/pkg/api/v1alpha1/router.go
+++ b/pkg/api/v1alpha1/router.go
@@ -681,7 +681,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("CreateSystemExtensionResource"),
 		r.AuthMW.AuthRequired(createScopesWithOpenID("governor:extensionresources")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
-		r.mwExtensionEnabledCheck,
+		r.mwExtensionResourcesEnabledCheck,
 		r.createSystemExtensionResource,
 	)
 
@@ -704,7 +704,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("UpdateSystemExtensionResource"),
 		r.AuthMW.AuthRequired(createScopesWithOpenID("governor:extensionresources")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
-		r.mwExtensionEnabledCheck,
+		r.mwExtensionResourcesEnabledCheck,
 		r.updateSystemExtensionResource,
 	)
 
@@ -713,7 +713,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("DeleteSystemExtensionResource"),
 		r.AuthMW.AuthRequired(createScopesWithOpenID("governor:extensionresources")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
-		r.mwExtensionEnabledCheck,
+		r.mwExtensionResourcesEnabledCheck,
 		r.deleteSystemExtensionResource,
 	)
 
@@ -723,7 +723,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("CreateUserExtensionResource"),
 		r.AuthMW.AuthRequired(createScopesWithOpenID("governor:users")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
-		r.mwExtensionEnabledCheck,
+		r.mwExtensionResourcesEnabledCheck,
 		r.createUserExtensionResource,
 	)
 
@@ -732,7 +732,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("CreateAuthenticatedUserExtensionResource"),
 		r.AuthMW.AuthRequired([]string{oidcScope}),
 		r.mwUserAuthRequired(AuthRoleUser),
-		r.mwExtensionEnabledCheck,
+		r.mwExtensionResourcesEnabledCheck,
 		r.createUserExtensionResource,
 	)
 
@@ -773,7 +773,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("UpdateUserExtensionResource"),
 		r.AuthMW.AuthRequired(updateScopesWithOpenID("governor:users")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
-		r.mwExtensionEnabledCheck,
+		r.mwExtensionResourcesEnabledCheck,
 		r.updateUserExtensionResource,
 	)
 
@@ -782,7 +782,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("UpdateAuthenticatedUserExtensionResources"),
 		r.AuthMW.AuthRequired([]string{oidcScope}),
 		r.mwUserAuthRequired(AuthRoleUser),
-		r.mwExtensionEnabledCheck,
+		r.mwExtensionResourcesEnabledCheck,
 		r.updateUserExtensionResource,
 	)
 
@@ -791,7 +791,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("DeleteUserExtensionResource"),
 		r.AuthMW.AuthRequired(deleteScopesWithOpenID("governor:users")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
-		r.mwExtensionEnabledCheck,
+		r.mwExtensionResourcesEnabledCheck,
 		r.deleteUserExtensionResource,
 	)
 
@@ -800,7 +800,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("DeleteAuthenticatedUserExtensionResources"),
 		r.AuthMW.AuthRequired([]string{oidcScope}),
 		r.mwUserAuthRequired(AuthRoleUser),
-		r.mwExtensionEnabledCheck,
+		r.mwExtensionResourcesEnabledCheck,
 		r.deleteUserExtensionResource,
 	)
 }

--- a/pkg/api/v1alpha1/router.go
+++ b/pkg/api/v1alpha1/router.go
@@ -621,6 +621,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("CreateExtensionResourceDefinition"),
 		r.AuthMW.AuthRequired(createScopesWithOpenID("governor:extensions")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
+		r.mwExtensionEnabledCheck,
 		r.createExtensionResourceDefinition,
 	)
 
@@ -643,6 +644,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("UpdateExtensionResourceDefinitionByID"),
 		r.AuthMW.AuthRequired(updateScopesWithOpenID("governor:extensions")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
+		r.mwExtensionEnabledCheck,
 		r.updateExtensionResourceDefinition,
 	)
 
@@ -651,6 +653,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("UpdateExtensionResourceDefinitionBySlug"),
 		r.AuthMW.AuthRequired(updateScopesWithOpenID("governor:extensions")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
+		r.mwExtensionEnabledCheck,
 		r.updateExtensionResourceDefinition,
 	)
 
@@ -659,6 +662,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("DeleteExtensionResourceDefinitionByID"),
 		r.AuthMW.AuthRequired(deleteScopesWithOpenID("governor:extensions")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
+		r.mwExtensionEnabledCheck,
 		r.deleteExtensionResourceDefinition,
 	)
 
@@ -667,6 +671,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("DeleteExtensionResourceDefinitionBySlug"),
 		r.AuthMW.AuthRequired(deleteScopesWithOpenID("governor:extensions")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
+		r.mwExtensionEnabledCheck,
 		r.deleteExtensionResourceDefinition,
 	)
 
@@ -676,6 +681,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("CreateSystemExtensionResource"),
 		r.AuthMW.AuthRequired(createScopesWithOpenID("governor:extensionresources")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
+		r.mwExtensionEnabledCheck,
 		r.createSystemExtensionResource,
 	)
 
@@ -698,6 +704,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("UpdateSystemExtensionResource"),
 		r.AuthMW.AuthRequired(createScopesWithOpenID("governor:extensionresources")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
+		r.mwExtensionEnabledCheck,
 		r.updateSystemExtensionResource,
 	)
 
@@ -706,6 +713,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("DeleteSystemExtensionResource"),
 		r.AuthMW.AuthRequired(createScopesWithOpenID("governor:extensionresources")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
+		r.mwExtensionEnabledCheck,
 		r.deleteSystemExtensionResource,
 	)
 
@@ -715,6 +723,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("CreateUserExtensionResource"),
 		r.AuthMW.AuthRequired(createScopesWithOpenID("governor:users")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
+		r.mwExtensionEnabledCheck,
 		r.createUserExtensionResource,
 	)
 
@@ -723,6 +732,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("CreateAuthenticatedUserExtensionResource"),
 		r.AuthMW.AuthRequired([]string{oidcScope}),
 		r.mwUserAuthRequired(AuthRoleUser),
+		r.mwExtensionEnabledCheck,
 		r.createUserExtensionResource,
 	)
 
@@ -763,6 +773,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("UpdateUserExtensionResource"),
 		r.AuthMW.AuthRequired(updateScopesWithOpenID("governor:users")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
+		r.mwExtensionEnabledCheck,
 		r.updateUserExtensionResource,
 	)
 
@@ -771,6 +782,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("UpdateAuthenticatedUserExtensionResources"),
 		r.AuthMW.AuthRequired([]string{oidcScope}),
 		r.mwUserAuthRequired(AuthRoleUser),
+		r.mwExtensionEnabledCheck,
 		r.updateUserExtensionResource,
 	)
 
@@ -779,6 +791,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("DeleteUserExtensionResource"),
 		r.AuthMW.AuthRequired(deleteScopesWithOpenID("governor:users")),
 		r.mwUserAuthRequired(AuthRoleAdmin),
+		r.mwExtensionEnabledCheck,
 		r.deleteUserExtensionResource,
 	)
 
@@ -787,6 +800,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		r.AuditMW.AuditWithType("DeleteAuthenticatedUserExtensionResources"),
 		r.AuthMW.AuthRequired([]string{oidcScope}),
 		r.mwUserAuthRequired(AuthRoleUser),
+		r.mwExtensionEnabledCheck,
 		r.deleteUserExtensionResource,
 	)
 }

--- a/pkg/api/v1alpha1/sys_extension_resources_test.go
+++ b/pkg/api/v1alpha1/sys_extension_resources_test.go
@@ -156,7 +156,9 @@ func (s *SystemExtensionResourceTestSuite) TestFindERDForExtensionResource() {
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
-			ext, erd, err := findERDForExtensionResource(context.Background(), s.db, tt.extensionSlug, tt.erdSlugPlural, tt.erdVersion)
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest("GET", "/", nil)
+			ext, erd, err := findERDForExtensionResource(c, s.db, tt.extensionSlug, tt.erdSlugPlural, tt.erdVersion)
 
 			if tt.expectedErr != nil {
 				assert.NotNil(t, err)

--- a/pkg/api/v1alpha1/user_extension_resources.go
+++ b/pkg/api/v1alpha1/user_extension_resources.go
@@ -69,7 +69,7 @@ func fetchUserAndERD(c *gin.Context, db boil.ContextExecutor) (
 	fetchERD := func(ctx context.Context, exec boil.ContextExecutor, exSlug, erdSlug, erdVersion string) {
 		defer fetchWg.Done()
 
-		extension, erd, findERDErr = findERDForExtensionResource(ctx, exec, exSlug, erdSlug, erdVersion)
+		extension, erd, findERDErr = findERDForExtensionResource(c, exec, exSlug, erdSlug, erdVersion)
 	}
 	go fetchERD(c.Request.Context(), db, extensionSlug, erdSlugPlural, erdVersion)
 


### PR DESCRIPTION
Add a middleware on extension routes to:
- reject any update/create/delete on extension resources whose extension or ERD is disabled
- use `gin.Context` to cache the DB query results throughout a request to reduce duplicate queries
