### PR TITLE
Fix membership bugs with deleted groups in hierarchical relationships

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -33,7 +33,7 @@ create NAME [sql|go] Creates new migration file with the current timestamp
 fix                  Apply sequential ordering to migrations
 	`,
 	Args: cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		migrate(args[0], args[1:])
 	},
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -19,7 +19,7 @@ import (
 var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "starts the governor api server",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return startAPI()
 	},
 }

--- a/internal/dbtools/membership_enumeration_test.go
+++ b/internal/dbtools/membership_enumeration_test.go
@@ -251,23 +251,25 @@ func TestHierarchyWouldCreateCycle(t *testing.T) {
 	}
 }
 
-// Sets this up:										
-//                                        ┌──────┐         
-//                                    ┌───┤Group1│         
-//                                    │   └─┬─┬──┘         
-//                                    ▼     │ │            
-//                                ┌──────┐  │ ▼            
-//          ┌─────────────────┬───┤Group2│  │User1         
-//          │                 │   └───┬──┘  │              
-//          ▼                 ▼       │     │              
-// ┌────────────────┐     ┌──────┐    ▼     │              
-// │Group4 (Deleted)│     │Group3│   User2  │              
-// └───┬────────┬───┘     └┬──┬──┘          │              
-//     │        │          │  │             │              
-//     ▼        ▼          │  ▼             │              
-// ┌──────┐   User5        │ User3          ▼              
-// │Group5│                └────────────► User4            
-// └──────┘                                                
+// nolint:all
+// Sets this up:
+//                                        ┌──────┐
+//                                    ┌───┤Group1│
+//                                    │   └─┬─┬──┘
+//                                    ▼     │ │
+//                                ┌──────┐  │ ▼
+//          ┌─────────────────┬───┤Group2│  │User1
+//          │                 │   └───┬──┘  │
+//          ▼                 ▼       │     │
+// ┌────────────────┐     ┌──────┐    ▼     │
+// │Group4 (Deleted)│     │Group3│   User2  │
+// └───┬────────┬───┘     └┬──┬──┘          │
+//     │        │          │  │             │
+//     ▼        ▼          │  ▼             │
+// ┌──────┐   User5        │ User3          ▼
+// │Group5│                └────────────► User4
+// └──────┘
+
 func seedTestDB(db *sql.DB) error {
 	testData := []string{
 		`INSERT INTO "users" ("id", "external_id", "name", "email", "login_count", "avatar_url", "last_login_at", "created_at", "updated_at", "github_id", "github_username", "deleted_at", "status") VALUES

--- a/internal/dbtools/membership_enumeration_test.go
+++ b/internal/dbtools/membership_enumeration_test.go
@@ -51,7 +51,7 @@ func TestServerRunning(t *testing.T) {
 	scan := r.Scan(&c)
 
 	assert.NoError(t, scan)
-	assert.Equal(t, c, 4)
+	assert.Equal(t, c, 5)
 }
 
 func TestGetMembershipsForUser(t *testing.T) {
@@ -127,6 +127,7 @@ func TestGetMembershipsForUser(t *testing.T) {
 				ExpiresAt: null.Time{},
 			},
 		},
+		"00000001-0000-0000-0000-000000000005": {},
 	}
 
 	for user, expect := range testCases {
@@ -236,6 +237,7 @@ func TestHierarchyWouldCreateCycle(t *testing.T) {
 		{parent: "00000002-0000-0000-0000-000000000003", member: "00000002-0000-0000-0000-000000000001"}: true,
 		{parent: "00000002-0000-0000-0000-000000000003", member: "00000002-0000-0000-0000-000000000002"}: true,
 		{parent: "00000002-0000-0000-0000-000000000003", member: "00000002-0000-0000-0000-000000000003"}: true,
+		{parent: "00000002-0000-0000-0000-000000000005", member: "00000002-0000-0000-0000-000000000002"}: false, // tests that cycle detection ignores deleted groups
 	}
 
 	for test, expect := range testCases {
@@ -249,23 +251,23 @@ func TestHierarchyWouldCreateCycle(t *testing.T) {
 	}
 }
 
-// Sets this up:
-//
-//	                ┌──────┐
-//	            ┌───┤Group1│
-//	            │   └─┬─┬──┘
-//	            ▼     │ │
-//	        ┌──────┐  │ ▼
-//	    ┌───┤Group2│  │User1
-//	    │   └───┬──┘  │
-//	    ▼       │     │
-//	┌──────┐    ▼     │
-//	│Group3│   User2  │
-//	└┬──┬──┘          │
-//	 │  │             │
-//	 │  ▼             │
-//	 │ User3          ▼
-//	 └────────────► User4
+// Sets this up:										
+//                                        ┌──────┐         
+//                                    ┌───┤Group1│         
+//                                    │   └─┬─┬──┘         
+//                                    ▼     │ │            
+//                                ┌──────┐  │ ▼            
+//          ┌─────────────────┬───┤Group2│  │User1         
+//          │                 │   └───┬──┘  │              
+//          ▼                 ▼       │     │              
+// ┌────────────────┐     ┌──────┐    ▼     │              
+// │Group4 (Deleted)│     │Group3│   User2  │              
+// └───┬────────┬───┘     └┬──┬──┘          │              
+//     │        │          │  │             │              
+//     ▼        ▼          │  ▼             │              
+// ┌──────┐   User5        │ User3          ▼              
+// │Group5│                └────────────► User4            
+// └──────┘                                                
 func seedTestDB(db *sql.DB) error {
 	testData := []string{
 		`INSERT INTO "users" ("id", "external_id", "name", "email", "login_count", "avatar_url", "last_login_at", "created_at", "updated_at", "github_id", "github_username", "deleted_at", "status") VALUES
@@ -276,6 +278,8 @@ func seedTestDB(db *sql.DB) error {
 		('00000001-0000-0000-0000-000000000003', NULL, 'User3', 'user3@email.com', 0, NULL, NULL, '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', NULL, NULL, NULL, 'pending');`,
 		`INSERT INTO "users" ("id", "external_id", "name", "email", "login_count", "avatar_url", "last_login_at", "created_at", "updated_at", "github_id", "github_username", "deleted_at", "status") VALUES
 		('00000001-0000-0000-0000-000000000004', NULL, 'User4', 'user4@email.com', 0, NULL, NULL, '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', NULL, NULL, NULL, 'pending');`,
+		`INSERT INTO "users" ("id", "external_id", "name", "email", "login_count", "avatar_url", "last_login_at", "created_at", "updated_at", "github_id", "github_username", "deleted_at", "status") VALUES
+		('00000001-0000-0000-0000-000000000005', NULL, 'User5', 'user5@email.com', 0, NULL, NULL, '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', NULL, NULL, NULL, 'pending');`,
 
 		`INSERT INTO "groups" ("id", "name", "slug", "description", "created_at", "updated_at", "deleted_at", "note") VALUES
 		('00000002-0000-0000-0000-000000000001', 'Group1', 'group-1', 'group-1', '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', NULL, '');`,
@@ -283,6 +287,10 @@ func seedTestDB(db *sql.DB) error {
 		('00000002-0000-0000-0000-000000000002', 'Group2', 'group-2', 'group-2', '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', NULL, '');`,
 		`INSERT INTO "groups" ("id", "name", "slug", "description", "created_at", "updated_at", "deleted_at", "note") VALUES
 		('00000002-0000-0000-0000-000000000003', 'Group3', 'group-3', 'group-3', '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', NULL, '');`,
+		`INSERT INTO "groups" ("id", "name", "slug", "description", "created_at", "updated_at", "deleted_at", "note") VALUES
+		('00000002-0000-0000-0000-000000000004', 'Group4', 'group-4', 'group-4', '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', '');`,
+		`INSERT INTO "groups" ("id", "name", "slug", "description", "created_at", "updated_at", "deleted_at", "note") VALUES
+		('00000002-0000-0000-0000-000000000005', 'Group5', 'group-5', 'group-5', '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', NULL, '');`,
 
 		`INSERT INTO "group_memberships" ("id", "group_id", "user_id", "is_admin", "created_at", "updated_at", "expires_at") VALUES
 		('00000003-0000-0000-0000-000000000001', '00000002-0000-0000-0000-000000000001', '00000001-0000-0000-0000-000000000001', 't', '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', NULL);`,
@@ -294,11 +302,17 @@ func seedTestDB(db *sql.DB) error {
 		('00000003-0000-0000-0000-000000000004', '00000002-0000-0000-0000-000000000001', '00000001-0000-0000-0000-000000000004', 'f', '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', NULL);`,
 		`INSERT INTO "group_memberships" ("id", "group_id", "user_id", "is_admin", "created_at", "updated_at", "expires_at") VALUES
 		('00000003-0000-0000-0000-000000000005', '00000002-0000-0000-0000-000000000003', '00000001-0000-0000-0000-000000000004', 'f', '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', NULL);`,
+		`INSERT INTO "group_memberships" ("id", "group_id", "user_id", "is_admin", "created_at", "updated_at", "expires_at") VALUES
+		('00000003-0000-0000-0000-000000000006', '00000002-0000-0000-0000-000000000004', '00000001-0000-0000-0000-000000000005', 'f', '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', NULL);`,
 
 		`INSERT INTO "group_hierarchies" ("id", "parent_group_id", "member_group_id", "created_at", "updated_at", "expires_at") VALUES
 		('00000004-0000-0000-0000-000000000001', '00000002-0000-0000-0000-000000000001', '00000002-0000-0000-0000-000000000002', '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', NULL);`,
 		`INSERT INTO "group_hierarchies" ("id", "parent_group_id", "member_group_id", "created_at", "updated_at", "expires_at") VALUES
 		('00000004-0000-0000-0000-000000000002', '00000002-0000-0000-0000-000000000002', '00000002-0000-0000-0000-000000000003', '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', NULL);`,
+		`INSERT INTO "group_hierarchies" ("id", "parent_group_id", "member_group_id", "created_at", "updated_at", "expires_at") VALUES
+		('00000004-0000-0000-0000-000000000003', '00000002-0000-0000-0000-000000000002', '00000002-0000-0000-0000-000000000004', '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', NULL);`,
+		`INSERT INTO "group_hierarchies" ("id", "parent_group_id", "member_group_id", "created_at", "updated_at", "expires_at") VALUES
+		('00000004-0000-0000-0000-000000000004', '00000002-0000-0000-0000-000000000004', '00000002-0000-0000-0000-000000000005', '2023-07-12 12:00:00.000000+00', '2023-07-12 12:00:00.000000+00', NULL);`,
 	}
 	for _, q := range testData {
 		_, err := db.Query(q)

--- a/internal/dbtools/notification_preferences_test.go
+++ b/internal/dbtools/notification_preferences_test.go
@@ -153,7 +153,7 @@ func (s *NotificationPreferencesTestSuite) TestNotificationDefaults() {
 	}
 
 	for _, tc := range tests {
-		s.T().Run(tc.name, func(t *testing.T) {
+		s.T().Run(tc.name, func(_ *testing.T) {
 			_, err := s.db.Query(tc.q)
 
 			if tc.wantQueryErr {
@@ -442,7 +442,7 @@ func (s *NotificationPreferencesTestSuite) TestNotificationPreferences() {
 	}
 
 	for _, tc := range tests {
-		s.T().Run(tc.name, func(t *testing.T) {
+		s.T().Run(tc.name, func(_ *testing.T) {
 			if tc.action != nil {
 				err := tc.action()
 

--- a/internal/dbtools/testtools.go
+++ b/internal/dbtools/testtools.go
@@ -65,7 +65,9 @@ func DatabaseTest(t *testing.T) *sqlx.DB {
 
 	t.Cleanup(func() {
 		cleanDB()
+
 		err := addFixtures()
+
 		require.NoError(t, err, "Unexpected error setting up fixture data")
 	})
 

--- a/internal/eventbus/client_test.go
+++ b/internal/eventbus/client_test.go
@@ -169,6 +169,7 @@ func TestClient_Publish(t *testing.T) {
 				tracer: otel.GetTracerProvider().Tracer("test"),
 			}
 			err := c.Publish(context.TODO(), tt.sub, tt.event)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/api/v1alpha1/user_extension_resources.go
+++ b/pkg/api/v1alpha1/user_extension_resources.go
@@ -66,7 +66,7 @@ func fetchUserAndERD(c *gin.Context, db boil.ContextExecutor) (
 	// find ERD
 	fetchWg.Add(1)
 
-	fetchERD := func(ctx context.Context, exec boil.ContextExecutor, exSlug, erdSlug, erdVersion string) {
+	fetchERD := func(_ context.Context, exec boil.ContextExecutor, exSlug, erdSlug, erdVersion string) {
 		defer fetchWg.Done()
 
 		extension, erd, findERDErr = findERDForExtensionResource(c, exec, exSlug, erdSlug, erdVersion)

--- a/pkg/api/v1alpha1/user_extension_resources_test.go
+++ b/pkg/api/v1alpha1/user_extension_resources_test.go
@@ -415,6 +415,7 @@ func (s *UserExtensionResourceTestSuite) TestListUserExtensionResources() {
 					body, tt.expectedErrMsg, "Expected error message to contain %q, got %s",
 					tt.expectedErrMsg, body,
 				)
+
 				return
 			}
 
@@ -572,6 +573,7 @@ func (s *UserExtensionResourceTestSuite) TestGetUserExtensionResource() {
 					body, tt.expectedErrMsg, "Expected error message to contain %q, got %s",
 					tt.expectedErrMsg, body,
 				)
+
 				return
 			}
 
@@ -753,6 +755,7 @@ func (s *UserExtensionResourceTestSuite) TestCreateUserExtensionResource() {
 					body, tt.expectedErrMsg, "Expected error message to contain %q, got %s",
 					tt.expectedErrMsg, body,
 				)
+
 				return
 			}
 
@@ -956,6 +959,7 @@ func (s *UserExtensionResourceTestSuite) TestUpdateUserExtensionResource() {
 					body, tt.expectedErrMsg, "Expected error message to contain %q, got %s",
 					tt.expectedErrMsg, body,
 				)
+
 				return
 			}
 

--- a/pkg/client/extensions_test.go
+++ b/pkg/client/extensions_test.go
@@ -127,6 +127,7 @@ func TestClient_Extensions(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.Extensions(context.TODO(), false)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -217,6 +218,7 @@ func TestClient_Extension(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.Extension(context.TODO(), tt.id, false)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -326,6 +328,7 @@ func TestClient_CreateExtension(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.CreateExtension(context.TODO(), tt.req)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -444,6 +447,7 @@ func TestClient_UpdateExtension(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.UpdateExtension(context.TODO(), tt.id, tt.req)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -521,6 +525,7 @@ func TestClient_DeleteExtension(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			err := c.DeleteExtension(context.TODO(), tt.id)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/client/governor_test.go
+++ b/pkg/client/governor_test.go
@@ -415,6 +415,7 @@ func TestClient_Organization(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.Organization(context.TODO(), tt.id)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -489,6 +490,7 @@ func TestClient_Organizations(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.Organizations(context.TODO())
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/client/groups_test.go
+++ b/pkg/client/groups_test.go
@@ -175,6 +175,7 @@ func TestClient_Groups(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.Groups(context.TODO())
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -275,6 +276,7 @@ func TestClient_Group(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.Group(context.TODO(), tt.id, false)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -365,6 +367,7 @@ func TestClient_GroupMembers(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.GroupMembers(context.TODO(), tt.id)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -455,6 +458,7 @@ func TestClient_GroupMemberRequests(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.GroupMemberRequests(context.TODO(), tt.id)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -562,6 +566,7 @@ func TestClient_CreateGroup(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.CreateGroup(context.TODO(), tt.req)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -636,6 +641,7 @@ func TestClient_DeleteGroup(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			err := c.DeleteGroup(context.TODO(), tt.id)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -735,6 +741,7 @@ func TestClient_AddGroupMember(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			err := c.AddGroupMember(context.TODO(), tt.groupID, tt.userID, false)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -834,6 +841,7 @@ func TestClient_RemoveGroupMember(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			err := c.RemoveGroupMember(context.TODO(), tt.groupID, tt.userID)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -933,6 +941,7 @@ func TestClient_AddGroupToOrganization(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			err := c.AddGroupToOrganization(context.TODO(), tt.groupID, tt.orgID)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -1032,6 +1041,7 @@ func TestClient_RemoveGroupFromOrganization(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			err := c.RemoveGroupFromOrganization(context.TODO(), tt.groupID, tt.orgID)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -1106,6 +1116,7 @@ func TestClient_GroupMembersAll(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.GroupMembersAll(context.TODO(), false)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -1181,6 +1192,7 @@ func TestClient_GroupMemberRequestsAll(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.GroupMembershipRequestsAll(context.TODO(), false)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/client/hierarchies_test.go
+++ b/pkg/client/hierarchies_test.go
@@ -65,6 +65,7 @@ func TestClient_GroupHierarchies(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.GroupHierarchies(context.TODO())
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -153,6 +154,7 @@ func TestClient_MemberGroups(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.MemberGroups(context.TODO(), tt.id)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -224,6 +226,7 @@ func TestClient_AddMemberGroup(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			err := c.AddMemberGroup(context.TODO(), tt.parentGroupID, tt.memberGroupID, tt.expiresAt)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -294,6 +297,7 @@ func TestClient_UpdateMemberGroup(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			err := c.UpdateMemberGroup(context.TODO(), tt.parentGroupID, tt.memberGroupID, tt.expiresAt)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -361,6 +365,7 @@ func TestClient_DeleteMemberGroup(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			err := c.DeleteMemberGroup(context.TODO(), tt.parentGroupID, tt.memberGroupID)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/client/notification_preferences_test.go
+++ b/pkg/client/notification_preferences_test.go
@@ -137,6 +137,7 @@ func TestClient_NotificationPreferences(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.NotificationPreferences(context.TODO(), "")
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/client/notification_targets_test.go
+++ b/pkg/client/notification_targets_test.go
@@ -134,6 +134,7 @@ func TestClient_NotificationTargets(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.NotificationTargets(context.TODO(), false)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -224,6 +225,7 @@ func TestClient_NotificationTarget(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.NotificationTarget(context.TODO(), tt.id, false)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -333,6 +335,7 @@ func TestClient_CreateNotificationTarget(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.CreateNotificationTarget(context.TODO(), tt.req)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -456,6 +459,7 @@ func TestClient_UpdateNotificationTarget(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.UpdateNotificationTarget(context.TODO(), tt.id, tt.req)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -533,6 +537,7 @@ func TestClient_DeleteNotificationTarget(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			err := c.DeleteNotificationTarget(context.TODO(), tt.id)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/client/notification_types_test.go
+++ b/pkg/client/notification_types_test.go
@@ -134,6 +134,7 @@ func TestClient_NotificationTypes(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.NotificationTypes(context.TODO(), false)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -224,6 +225,7 @@ func TestClient_NotificationType(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.NotificationType(context.TODO(), tt.id, false)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -327,6 +329,7 @@ func TestClient_CreateNotificationType(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.CreateNotificationType(context.TODO(), tt.req)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -450,6 +453,7 @@ func TestClient_UpdateNotificationType(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.UpdateNotificationType(context.TODO(), tt.id, tt.req)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -527,6 +531,7 @@ func TestClient_DeleteNotificationType(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			err := c.DeleteNotificationType(context.TODO(), tt.id)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/client/users_test.go
+++ b/pkg/client/users_test.go
@@ -77,6 +77,7 @@ func TestClient_Users(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.Users(context.TODO(), false)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -151,6 +152,7 @@ func TestClient_UsersV2(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.UsersV2(context.TODO(), map[string][]string{})
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -239,6 +241,7 @@ func TestClient_User(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.User(context.TODO(), tt.id, false)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -345,6 +348,7 @@ func TestClient_CreateUser(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.CreateUser(context.TODO(), tt.req)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -421,6 +425,7 @@ func TestClient_DeleteUser(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			err := c.DeleteUser(context.TODO(), tt.id)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -547,6 +552,7 @@ func TestClient_UpdateUser(t *testing.T) {
 				token:                  &oauth2.Token{AccessToken: "topSekret"},
 			}
 			got, err := c.UpdateUser(context.TODO(), tt.id, tt.req)
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/jsonschema/unique_constraint_test.go
+++ b/pkg/jsonschema/unique_constraint_test.go
@@ -174,6 +174,7 @@ func (s *UniqueConstrainTestSuite) TestCompile() {
 				db:  nil,
 			}
 			_, err := uc.Compile(jsonschema.CompilerContext{}, tt.inputMap)
+
 			if tt.expectedErr == "" {
 				assert.Nil(t, err)
 			} else {
@@ -307,12 +308,14 @@ func TestAssertStringSlice(t *testing.T) {
 
 			if tt.expectedErr == "" {
 				assert.Nil(t, err)
+
 				if !reflect.DeepEqual(actual, tt.expected) {
 					t.Errorf("assertStringSlice() = %v, expected %v", actual, tt.expected)
 				}
 			} else {
 				assert.NotNil(t, err)
 				assert.Contains(t, err.Error(), tt.expectedErr)
+
 				return
 			}
 		})


### PR DESCRIPTION
Add checks and tests to ensure that deleted groups are not counted in hierarchical membership resolution or cycle checks