### PR TITLE
Approver group validity check

### DIFF
--- a/pkg/api/v1alpha1/authenticated_user.go
+++ b/pkg/api/v1alpha1/authenticated_user.go
@@ -269,7 +269,7 @@ func (r *Router) getAuthenticatedUserGroupApprovals(c *gin.Context) {
 			}
 		}
 
-		if groupHasNoAdmins && len(m.R.Group.R.ApproverGroupGroup.R.GroupMemberships) > 0 {
+		if groupHasNoAdmins && m.R.Group.ApproverGroup.Valid && len(m.R.Group.R.ApproverGroupGroup.R.GroupMemberships) > 0 {
 			groupHasNoAdmins = false
 		}
 


### PR DESCRIPTION
Ensure that the approver group is set before attempting to count the members to see if a membership request should fall back to the Governor global admins or not. This codepath is only hit when a membership request is made to an empty group.