### PR TITLE
update go version in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,4 +44,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_EXPERIMENTAL: 1
-          GOVERSION: "1.20"
+          GOVERSION: "1.22"


### PR DESCRIPTION
fixes [this](https://github.com/metal-toolbox/governor-api/actions/runs/9271905592/job/25508409480#step:7:29)

```
'go mod tidy': exit status 1: go: go.mod file indicates go 1.22, but maximum version supported by tidy is 1.20
```