### PR TITLE
fix memberships dbtools traces

### DIFF
--- a/pkg/api/v1alpha1/auth.go
+++ b/pkg/api/v1alpha1/auth.go
@@ -218,7 +218,7 @@ func (r *Router) mwUserAuthRequired(authRole mwAuthRole) gin.HandlerFunc {
 
 		r.Logger.Debug("got authenticated user", zap.Any("user", user))
 
-		enumeratedMemberships, err := dbtools.GetMembershipsForUser(c, r.DB.DB, user.ID, false)
+		enumeratedMemberships, err := dbtools.GetMembershipsForUser(c.Request.Context(), r.DB.DB, user.ID, false)
 		if err != nil {
 			sendError(c, http.StatusInternalServerError, "error getting enumerated groups: "+err.Error())
 			return
@@ -338,7 +338,7 @@ func (r *Router) mwGroupAuthRequired(authRole mwAuthRole) gin.HandlerFunc {
 			idIsSlug = true
 		}
 
-		enumeratedMemberships, err := dbtools.GetMembershipsForUser(c, r.DB.DB, user.ID, true)
+		enumeratedMemberships, err := dbtools.GetMembershipsForUser(c.Request.Context(), r.DB.DB, user.ID, true)
 		if err != nil {
 			sendError(c, http.StatusInternalServerError, "error getting enumerated groups: "+err.Error())
 			return

--- a/pkg/api/v1alpha1/authenticated_user.go
+++ b/pkg/api/v1alpha1/authenticated_user.go
@@ -94,7 +94,7 @@ func (r *Router) getAuthenticatedUser(c *gin.Context) {
 		return
 	}
 
-	enumeratedMemberships, err := dbtools.GetMembershipsForUser(c, r.DB.DB, ctxUser.ID, false)
+	enumeratedMemberships, err := dbtools.GetMembershipsForUser(c.Request.Context(), r.DB.DB, ctxUser.ID, false)
 	if err != nil {
 		sendError(c, http.StatusInternalServerError, "error enumerating group membership: "+err.Error())
 		return
@@ -141,7 +141,7 @@ func (r *Router) getAuthenticatedUserGroups(c *gin.Context) {
 
 	var userDirectGroups []string
 
-	enumeratedMemberships, err := dbtools.GetMembershipsForUser(c, r.DB.DB, ctxUser.ID, false)
+	enumeratedMemberships, err := dbtools.GetMembershipsForUser(c.Request.Context(), r.DB.DB, ctxUser.ID, false)
 	if err != nil {
 		sendError(c, http.StatusInternalServerError, "error enumerating group membership: "+err.Error())
 		return
@@ -214,7 +214,7 @@ func (r *Router) getAuthenticatedUserGroupApprovals(c *gin.Context) {
 
 	var userGroups, userAdminGroups []string
 
-	enumeratedMemberships, err := dbtools.GetMembershipsForUser(c, r.DB.DB, ctxUser.ID, false)
+	enumeratedMemberships, err := dbtools.GetMembershipsForUser(c.Request.Context(), r.DB.DB, ctxUser.ID, false)
 	if err != nil {
 		sendError(c, http.StatusInternalServerError, "error enumerating group membership: "+err.Error())
 		return

--- a/pkg/api/v1alpha1/extension_resource_auth.go
+++ b/pkg/api/v1alpha1/extension_resource_auth.go
@@ -111,7 +111,7 @@ func (r *Router) mwSystemExtensionResourceGroupAuth(c *gin.Context) {
 	adminGroupID := erd.AdminGroup.String
 
 	// check if user is part of the admin group
-	enumeratedMemberships, err := dbtools.GetMembershipsForUser(c, r.DB.DB, user.ID, false)
+	enumeratedMemberships, err := dbtools.GetMembershipsForUser(c.Request.Context(), r.DB.DB, user.ID, false)
 	if err != nil {
 		sendError(c, http.StatusInternalServerError, "error getting enumerated groups: "+err.Error())
 		return

--- a/pkg/api/v1alpha1/group_applications.go
+++ b/pkg/api/v1alpha1/group_applications.go
@@ -729,7 +729,7 @@ func (r *Router) processGroupAppRequest(c *gin.Context) {
 	// check that the authenticated user is member of the approver group
 	isApprover := false
 
-	enumeratedMemberships, err := dbtools.GetMembershipsForUser(c, r.DB.DB, ctxUser.ID, false)
+	enumeratedMemberships, err := dbtools.GetMembershipsForUser(c.Request.Context(), r.DB.DB, ctxUser.ID, false)
 	if err != nil {
 		sendError(c, http.StatusInternalServerError, "error enumerating group membership: "+err.Error())
 		return

--- a/pkg/api/v1alpha1/group_hierarchies.go
+++ b/pkg/api/v1alpha1/group_hierarchies.go
@@ -134,7 +134,7 @@ func (r *Router) addMemberGroup(c *gin.Context) {
 		return
 	}
 
-	createsCycle, err := dbtools.HierarchyWouldCreateCycle(c, tx, parentGroup.ID, memberGroup.ID)
+	createsCycle, err := dbtools.HierarchyWouldCreateCycle(c.Request.Context(), tx, parentGroup.ID, memberGroup.ID)
 	if err != nil {
 		rollbackWithError(c, tx, err, http.StatusInternalServerError, "could not determine whether the desired hierarchy creates a cycle")
 
@@ -159,7 +159,7 @@ func (r *Router) addMemberGroup(c *gin.Context) {
 		ExpiresAt:     req.ExpiresAt,
 	}
 
-	membershipsBefore, err := dbtools.GetAllGroupMemberships(c, tx, false)
+	membershipsBefore, err := dbtools.GetAllGroupMemberships(c.Request.Context(), tx, false)
 	if err != nil {
 		rollbackWithError(c, tx, err, http.StatusBadRequest, "failed to compute new effective memberships")
 
@@ -185,7 +185,7 @@ func (r *Router) addMemberGroup(c *gin.Context) {
 		return
 	}
 
-	membershipsAfter, err := dbtools.GetAllGroupMemberships(c, tx, false)
+	membershipsAfter, err := dbtools.GetAllGroupMemberships(c.Request.Context(), tx, false)
 	if err != nil {
 		rollbackWithError(c, tx, err, http.StatusBadRequest, "failed to compute new effective memberships")
 
@@ -334,7 +334,7 @@ func (r *Router) removeMemberGroup(c *gin.Context) {
 		return
 	}
 
-	membershipsBefore, err := dbtools.GetAllGroupMemberships(c, tx, false)
+	membershipsBefore, err := dbtools.GetAllGroupMemberships(c.Request.Context(), tx, false)
 	if err != nil {
 		rollbackWithError(c, tx, err, http.StatusBadRequest, "failed to compute new effective memberships")
 
@@ -360,7 +360,7 @@ func (r *Router) removeMemberGroup(c *gin.Context) {
 		return
 	}
 
-	membershipsAfter, err := dbtools.GetAllGroupMemberships(c, tx, false)
+	membershipsAfter, err := dbtools.GetAllGroupMemberships(c.Request.Context(), tx, false)
 	if err != nil {
 		rollbackWithError(c, tx, err, http.StatusBadRequest, "failed to compute new effective memberships")
 

--- a/pkg/api/v1alpha1/group_membership.go
+++ b/pkg/api/v1alpha1/group_membership.go
@@ -103,7 +103,7 @@ func (r *Router) listGroupMembers(c *gin.Context) {
 		return
 	}
 
-	enumeratedMembers, err := dbtools.GetMembersOfGroup(c, r.DB.DB, group.ID, true)
+	enumeratedMembers, err := dbtools.GetMembersOfGroup(c.Request.Context(), r.DB.DB, group.ID, true)
 	if err != nil {
 		sendError(c, http.StatusInternalServerError, "error enumerating group membership: "+err.Error())
 		return
@@ -201,7 +201,7 @@ func (r *Router) addGroupMember(c *gin.Context) {
 		return
 	}
 
-	membershipsBefore, err := dbtools.GetMembershipsForUser(c, tx, user.ID, false)
+	membershipsBefore, err := dbtools.GetMembershipsForUser(c.Request.Context(), tx, user.ID, false)
 	if err != nil {
 		msg := "failed to compute new effective memberships: " + err.Error()
 
@@ -251,7 +251,7 @@ func (r *Router) addGroupMember(c *gin.Context) {
 		return
 	}
 
-	membershipsAfter, err := dbtools.GetMembershipsForUser(c, tx, user.ID, false)
+	membershipsAfter, err := dbtools.GetMembershipsForUser(c.Request.Context(), tx, user.ID, false)
 	if err != nil {
 		msg := "failed to compute new effective memberships: " + err.Error()
 
@@ -505,7 +505,7 @@ func (r *Router) removeGroupMember(c *gin.Context) {
 		return
 	}
 
-	membershipsBefore, err := dbtools.GetMembershipsForUser(c, tx, user.ID, false)
+	membershipsBefore, err := dbtools.GetMembershipsForUser(c.Request.Context(), tx, user.ID, false)
 	if err != nil {
 		msg := "failed to compute new effective memberships: " + err.Error()
 
@@ -555,7 +555,7 @@ func (r *Router) removeGroupMember(c *gin.Context) {
 		return
 	}
 
-	membershipsAfter, err := dbtools.GetMembershipsForUser(c, tx, user.ID, false)
+	membershipsAfter, err := dbtools.GetMembershipsForUser(c.Request.Context(), tx, user.ID, false)
 	if err != nil {
 		msg := "failed to compute new effective memberships: " + err.Error()
 
@@ -1057,7 +1057,7 @@ func (r *Router) processGroupRequest(c *gin.Context) {
 			return
 		}
 
-		membershipsBefore, err := dbtools.GetMembershipsForUser(c, tx, user.ID, false)
+		membershipsBefore, err := dbtools.GetMembershipsForUser(c.Request.Context(), tx, user.ID, false)
 		if err != nil {
 			msg := "failed to compute new effective memberships: " + err.Error()
 
@@ -1146,7 +1146,7 @@ func (r *Router) processGroupRequest(c *gin.Context) {
 			return
 		}
 
-		membershipsAfter, err := dbtools.GetMembershipsForUser(c, tx, user.ID, false)
+		membershipsAfter, err := dbtools.GetMembershipsForUser(c.Request.Context(), tx, user.ID, false)
 		if err != nil {
 			msg := "failed to compute new effective memberships: " + err.Error()
 
@@ -1316,7 +1316,7 @@ func (r *Router) getGroupMembershipsAll(c *gin.Context) {
 			}
 		}
 	} else {
-		enumeratedMemberships, err := dbtools.GetAllGroupMemberships(c, r.DB.DB, true)
+		enumeratedMemberships, err := dbtools.GetAllGroupMemberships(c.Request.Context(), r.DB.DB, true)
 		if err != nil {
 			sendError(c, http.StatusInternalServerError, "error getting group memberships"+err.Error())
 			return

--- a/pkg/api/v1alpha1/groups.go
+++ b/pkg/api/v1alpha1/groups.go
@@ -106,7 +106,7 @@ func (r *Router) getGroup(c *gin.Context) {
 		return
 	}
 
-	enumeratedMembers, err := dbtools.GetMembersOfGroup(c, r.DB.DB, group.ID, false)
+	enumeratedMembers, err := dbtools.GetMembersOfGroup(c.Request.Context(), r.DB.DB, group.ID, false)
 	if err != nil {
 		sendError(c, http.StatusInternalServerError, "error enumerating group membership: "+err.Error())
 		return

--- a/pkg/api/v1alpha1/users.go
+++ b/pkg/api/v1alpha1/users.go
@@ -130,7 +130,7 @@ func (r *Router) getUser(c *gin.Context) {
 		return
 	}
 
-	enumeratedMemberships, err := dbtools.GetMembershipsForUser(c, r.DB.DB, user.ID, false)
+	enumeratedMemberships, err := dbtools.GetMembershipsForUser(c.Request.Context(), r.DB.DB, user.ID, false)
 	if err != nil {
 		sendError(c, http.StatusInternalServerError, "error enumerating group membership: "+err.Error())
 		return


### PR DESCRIPTION
Calls to fetch user/group memberships using dbtools was passing gin.Context as the context instead of the gin.Context's Request.Context() which is where all existing trace context is held.

This updates those calls to pass the request context so the traces are properly related.