### PR TITLE
Small Auth Fix

### DIFF
--- a/pkg/api/v1alpha1/extension_resource_auth.go
+++ b/pkg/api/v1alpha1/extension_resource_auth.go
@@ -52,6 +52,11 @@ func getCtxExtension(c *gin.Context) *models.Extension {
 }
 
 func (r *Router) mwSystemExtensionResourceGroupAuth(c *gin.Context) {
+	if !contains(c.GetStringSlice("jwt.roles"), oidcScope) {
+		r.Logger.Debug("oidc scope not found, skipping user authorization check", zap.String("oidcScope", oidcScope))
+		return
+	}
+
 	user := getCtxUser(c)
 	if user == nil {
 		r.Logger.Error("user not found in context")


### PR DESCRIPTION
User auth for system resources should be skipped if there's not `oidc` in scope, which indicates the request is from an oidc client