### PR TITLE
Add offset to allow for random page access

### DIFF
--- a/pkg/api/v1beta1/pagination.go
+++ b/pkg/api/v1beta1/pagination.go
@@ -23,6 +23,7 @@ const (
 // PaginationParams is the params to be parsed from query params from a gin context
 type PaginationParams struct {
 	Limit      int    `json:"limit,omitempty"`
+	Offset     int    `json:"offset,omitempty"`
 	Last       bool   `json:"last,omitempty"`
 	NextCursor string `json:"next_cursor,omitempty"`
 	PrevCursor string `json:"prev_cursor,omitempty"`

--- a/pkg/api/v1beta1/users.go
+++ b/pkg/api/v1beta1/users.go
@@ -23,7 +23,7 @@ const (
 )
 
 var (
-	permittedListUsersParams = []string{"external_id", "email", "deleted", "limit", "sort_by", "sort_order", "search", "status[]", "next_cursor", "prev_cursor", "last"}
+	permittedListUsersParams = []string{"external_id", "email", "deleted", "limit", "sort_by", "sort_order", "search", "status[]", "next_cursor", "prev_cursor", "last", "offset"}
 	validStatuses            = []string{UserStatusActive, UserStatusPending, UserStatusSuspended}
 	allowedSortCols          = []string{"name", "email", "id"}
 )
@@ -115,6 +115,11 @@ func (r *Router) listUsers(c *gin.Context) {
 
 	// retrieve limit used + 1 so we can check if there are more records
 	queryMods = append(queryMods, qm.Limit(p.Limit+1))
+
+	// allow for pagination by offset, useful for random page access
+	if _, ok := c.GetQuery("offset"); ok {
+		queryMods = append(queryMods, qm.Offset(p.Offset))
+	}
 
 	if contains(allowedSortCols, strings.ToLower(p.SortBy)) {
 		queryMods = append(queryMods, qm.OrderBy(p.SortBy+" "+p.SortOrder))


### PR DESCRIPTION
We already allow specifying a limit for the query, and while we support cursor-based pagination, we order by ID by default, so offset-based pagination means use-cases like a GetAll SCIM operation which fetch by index are easier to implement.