### PR TITLE
Make sure and parse offset into the pagination struct

### DIFF
--- a/pkg/api/v1beta1/pagination.go
+++ b/pkg/api/v1beta1/pagination.go
@@ -67,6 +67,17 @@ func parsePagination(c *gin.Context) (PaginationParams, error) {
 		}
 	}
 
+	if offsetStr, ok := c.GetQuery("offset"); ok {
+		val, err := strconv.Atoi(offsetStr)
+		if err != nil {
+			return PaginationParams{}, invalidQueryParameterValue("offset, " + offsetStr)
+		}
+
+		if val > 0 {
+			p.Offset = val
+		}
+	}
+
 	if nextCursor, ok := c.GetQuery("next_cursor"); ok {
 		p.NextCursor = nextCursor
 	}

--- a/pkg/api/v1beta1/users.go
+++ b/pkg/api/v1beta1/users.go
@@ -117,7 +117,7 @@ func (r *Router) listUsers(c *gin.Context) {
 	queryMods = append(queryMods, qm.Limit(p.Limit+1))
 
 	// allow for pagination by offset, useful for random page access
-	if _, ok := c.GetQuery("offset"); ok {
+	if p.Offset > 0 {
 		queryMods = append(queryMods, qm.Offset(p.Offset))
 	}
 


### PR DESCRIPTION
In the previous PR, the offset value wasn't actually picked out from the query params and placed in the pagination struct.