### PR TITLE
Pin Down CRDB Test Server Version

### DIFF
--- a/internal/dbtools/membership_enumeration_test.go
+++ b/internal/dbtools/membership_enumeration_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/cockroachdb/cockroach-go/v2/testserver"
 	dbm "github.com/metal-toolbox/governor-api/db"
 	"github.com/pressly/goose/v3"
 	"github.com/stretchr/testify/assert"
@@ -16,7 +15,7 @@ import (
 var db *sql.DB
 
 func init() {
-	ts, err := testserver.NewTestServer()
+	ts, err := NewCRDBTestServer()
 	if err != nil {
 		panic(err)
 	}
@@ -351,24 +350,24 @@ func TestHierarchyWouldCreateCycle(t *testing.T) {
 
 // nolint:all
 // Sets this up:
-//                                        ┌──────┐  
-//                                    ┌───┤Group1│  
-//                                    │   └─┬─┬──┘  
-//                                    ▼     │ │     
-//                                ┌──────┐  │ ▼     
-//          ┌─────────────────┬───┤Group2│  │User1  
-//          │                 │   └───┬──┘  │       
-//          ▼                 ▼       │     │       
-// ┌────────────────┐     ┌──────┐    ▼     │       
-// │Group4 (Deleted)│     │Group3│   User2  │       
-// └───┬────────┬───┘     └┬──┬──┘          │       
-//     │        │          │  │             │       
-//     ▼        │          │  ▼             │       
-// ┌──────┐     │          │ User3          ▼       
-// │Group5│     │          └────────────► User4     
-// └───┬──┘     │                                   
-//     │        ▼                                   
-//     └────► User5                                 
+//                                        ┌──────┐
+//                                    ┌───┤Group1│
+//                                    │   └─┬─┬──┘
+//                                    ▼     │ │
+//                                ┌──────┐  │ ▼
+//          ┌─────────────────┬───┤Group2│  │User1
+//          │                 │   └───┬──┘  │
+//          ▼                 ▼       │     │
+// ┌────────────────┐     ┌──────┐    ▼     │
+// │Group4 (Deleted)│     │Group3│   User2  │
+// └───┬────────┬───┘     └┬──┬──┘          │
+//     │        │          │  │             │
+//     ▼        │          │  ▼             │
+// ┌──────┐     │          │ User3          ▼
+// │Group5│     │          └────────────► User4
+// └───┬──┘     │
+//     │        ▼
+//     └────► User5
 
 func seedTestDB(db *sql.DB) error {
 	testData := []string{

--- a/internal/dbtools/notification_preferences_test.go
+++ b/internal/dbtools/notification_preferences_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/cockroachdb/cockroach-go/v2/testserver"
 	"github.com/jmoiron/sqlx"
 	dbm "github.com/metal-toolbox/governor-api/db"
 	"github.com/metal-toolbox/governor-api/internal/models"
@@ -49,7 +48,7 @@ func (s *NotificationPreferencesTestSuite) seedTestDB() error {
 }
 
 func (s *NotificationPreferencesTestSuite) SetupSuite() {
-	ts, err := testserver.NewTestServer()
+	ts, err := NewCRDBTestServer()
 	if err != nil {
 		panic(err)
 	}

--- a/internal/dbtools/testing.go
+++ b/internal/dbtools/testing.go
@@ -3,7 +3,8 @@ package dbtools
 import "github.com/cockroachdb/cockroach-go/v2/testserver"
 
 // TestServerCRDBVersion is the version of CockroachDB that the test server is running
-const TestServerCRDBVersion = "v24.3.8"
+// v23.1.28 is the last version under BSL
+const TestServerCRDBVersion = "v23.1.28"
 
 // NewCRDBTestServer creates a new CockroachDB test server
 func NewCRDBTestServer() (testserver.TestServer, error) {

--- a/internal/dbtools/testing.go
+++ b/internal/dbtools/testing.go
@@ -1,0 +1,11 @@
+package dbtools
+
+import "github.com/cockroachdb/cockroach-go/v2/testserver"
+
+// TestServerCRDBVersion is the version of CockroachDB that the test server is running
+const TestServerCRDBVersion = "v24.3.8"
+
+// NewCRDBTestServer creates a new CockroachDB test server
+func NewCRDBTestServer() (testserver.TestServer, error) {
+	return testserver.NewTestServer(testserver.CustomVersionOpt(TestServerCRDBVersion))
+}

--- a/pkg/api/v1alpha1/extension_resource_auth_test.go
+++ b/pkg/api/v1alpha1/extension_resource_auth_test.go
@@ -10,12 +10,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/cockroachdb/cockroach-go/v2/testserver"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/metal-toolbox/auditevent/ginaudit"
 	dbm "github.com/metal-toolbox/governor-api/db"
+	"github.com/metal-toolbox/governor-api/internal/dbtools"
 	"github.com/metal-toolbox/governor-api/internal/eventbus"
 	"github.com/metal-toolbox/governor-api/internal/models"
 	"github.com/pressly/goose/v3"
@@ -221,7 +221,7 @@ func (s *ExtensionResourcesGroupAuthTestSuite) SetupSuite() {
 
 	s.conn = &mockNATSConn{}
 
-	ts, err := testserver.NewTestServer()
+	ts, err := dbtools.NewCRDBTestServer()
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/api/v1alpha1/extension_resource_definitions_test.go
+++ b/pkg/api/v1alpha1/extension_resource_definitions_test.go
@@ -10,12 +10,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/cockroachdb/cockroach-go/v2/testserver"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/metal-toolbox/auditevent/ginaudit"
 	dbm "github.com/metal-toolbox/governor-api/db"
+	"github.com/metal-toolbox/governor-api/internal/dbtools"
 	"github.com/metal-toolbox/governor-api/internal/eventbus"
 	"github.com/metal-toolbox/governor-api/internal/models"
 	events "github.com/metal-toolbox/governor-api/pkg/events/v1alpha1"
@@ -97,7 +97,7 @@ func (s *ExtensionResourceDefinitionsTestSuite) SetupSuite() {
 
 	gin.SetMode(gin.TestMode)
 
-	ts, err := testserver.NewTestServer()
+	ts, err := dbtools.NewCRDBTestServer()
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/api/v1alpha1/extensions_test.go
+++ b/pkg/api/v1alpha1/extensions_test.go
@@ -10,12 +10,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/cockroachdb/cockroach-go/v2/testserver"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/metal-toolbox/auditevent/ginaudit"
 	dbm "github.com/metal-toolbox/governor-api/db"
+	"github.com/metal-toolbox/governor-api/internal/dbtools"
 	"github.com/metal-toolbox/governor-api/internal/eventbus"
 	"github.com/metal-toolbox/governor-api/internal/models"
 	events "github.com/metal-toolbox/governor-api/pkg/events/v1alpha1"
@@ -69,7 +69,7 @@ func (s *ExtensionsTestSuite) SetupSuite() {
 
 	gin.SetMode(gin.TestMode)
 
-	ts, err := testserver.NewTestServer()
+	ts, err := dbtools.NewCRDBTestServer()
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/api/v1alpha1/sys_extension_resources_test.go
+++ b/pkg/api/v1alpha1/sys_extension_resources_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,11 +15,11 @@ import (
 	events "github.com/metal-toolbox/governor-api/pkg/events/v1alpha1"
 	"go.uber.org/zap"
 
-	"github.com/cockroachdb/cockroach-go/v2/testserver"
 	"github.com/gin-gonic/gin"
 	"github.com/jmoiron/sqlx"
 	"github.com/metal-toolbox/auditevent/ginaudit"
 	dbm "github.com/metal-toolbox/governor-api/db"
+	"github.com/metal-toolbox/governor-api/internal/dbtools"
 	"github.com/metal-toolbox/governor-api/internal/eventbus"
 	"github.com/pressly/goose/v3"
 	"github.com/stretchr/testify/assert"
@@ -93,7 +94,7 @@ func (s *SystemExtensionResourceTestSuite) SetupSuite() {
 
 	s.conn = &mockNATSConn{}
 
-	ts, err := testserver.NewTestServer()
+	ts, err := dbtools.NewCRDBTestServer()
 	if err != nil {
 		panic(err)
 	}
@@ -106,7 +107,7 @@ func (s *SystemExtensionResourceTestSuite) SetupSuite() {
 	goose.SetBaseFS(dbm.Migrations)
 
 	if err := goose.Up(s.db, "migrations"); err != nil {
-		panic("migration failed - could not set up test db")
+		panic(fmt.Sprintf("migration failed - could not set up test db: %s", err.Error()))
 	}
 
 	if err := s.seedTestDB(); err != nil {

--- a/pkg/api/v1alpha1/user_extension_resources_test.go
+++ b/pkg/api/v1alpha1/user_extension_resources_test.go
@@ -10,12 +10,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/cockroachdb/cockroach-go/v2/testserver"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/metal-toolbox/auditevent/ginaudit"
 	dbm "github.com/metal-toolbox/governor-api/db"
+	"github.com/metal-toolbox/governor-api/internal/dbtools"
 	"github.com/metal-toolbox/governor-api/internal/eventbus"
 	"github.com/metal-toolbox/governor-api/internal/models"
 	events "github.com/metal-toolbox/governor-api/pkg/events/v1alpha1"
@@ -107,7 +107,7 @@ func (s *UserExtensionResourceTestSuite) SetupSuite() {
 
 	s.conn = &mockNATSConn{}
 
-	ts, err := testserver.NewTestServer()
+	ts, err := dbtools.NewCRDBTestServer()
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/jsonschema/unique_constraint_test.go
+++ b/pkg/jsonschema/unique_constraint_test.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/cockroachdb/cockroach-go/v2/testserver"
 	dbm "github.com/metal-toolbox/governor-api/db"
+	"github.com/metal-toolbox/governor-api/internal/dbtools"
 	"github.com/metal-toolbox/governor-api/internal/models"
 	"github.com/pressly/goose/v3"
 	jsonschemav6 "github.com/santhosh-tekuri/jsonschema/v6"
@@ -50,7 +50,7 @@ func (s *UniqueConstrainTestSuite) seedTestDB() error {
 }
 
 func (s *UniqueConstrainTestSuite) SetupSuite() {
-	ts, err := testserver.NewTestServer()
+	ts, err := dbtools.NewCRDBTestServer()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The `testserver` package from crdb grabs the latest version of CRDB binary by default, and it breaks all our tests recently. This work adds the ability to pin down a specific version of CRDB for test purposes