### PR TITLE
fix: topological sort before restore

### DIFF
--- a/internal/backupper/groups.go
+++ b/internal/backupper/groups.go
@@ -1,0 +1,142 @@
+package backupper
+
+import (
+	crdbModels "github.com/metal-toolbox/governor-api/internal/models/crdb"
+	psqlModels "github.com/metal-toolbox/governor-api/internal/models/psql"
+	"go.uber.org/zap"
+)
+
+type sortable struct {
+	dbmodel interface{}
+	id      string
+	parent  string
+}
+
+func (b *Backupper) crdbGroupsToSortable(in crdbModels.GroupSlice) []*sortable {
+	out := []*sortable{}
+
+	for _, g := range in {
+		sg := &sortable{
+			dbmodel: g,
+			id:      g.ID,
+		}
+
+		if g.ApproverGroup.Valid {
+			sg.parent = g.ApproverGroup.String
+		}
+
+		out = append(out, sg)
+	}
+
+	return out
+}
+
+func (b *Backupper) psqlGroupsToSortable(in psqlModels.GroupSlice) []*sortable {
+	out := []*sortable{}
+
+	for _, g := range in {
+		sg := &sortable{
+			dbmodel: g,
+			id:      g.ID,
+		}
+
+		if g.ApproverGroup.Valid {
+			sg.parent = g.ApproverGroup.String
+		}
+
+		out = append(out, sg)
+	}
+
+	return out
+}
+
+// sortPSQLGroups sorts PSQL groups topologically and returns the correctly typed slice
+func (b *Backupper) sortPSQLGroups(in []*sortable) psqlModels.GroupSlice {
+	sorted := b.sort(in)
+	if sorted == nil {
+		return nil
+	}
+
+	result := make(psqlModels.GroupSlice, 0, len(sorted))
+
+	for _, g := range sorted {
+		if group, ok := g.dbmodel.(*psqlModels.Group); ok {
+			result = append(result, group)
+		}
+	}
+
+	return result
+}
+
+// sortCRDBGroups sorts CRDB groups topologically and returns the correctly typed slice
+func (b *Backupper) sortCRDBGroups(in []*sortable) crdbModels.GroupSlice {
+	sorted := b.sort(in)
+	if sorted == nil {
+		return nil
+	}
+
+	result := make(crdbModels.GroupSlice, 0, len(sorted))
+
+	for _, g := range sorted {
+		if group, ok := g.dbmodel.(*crdbModels.Group); ok {
+			result = append(result, group)
+		}
+	}
+
+	return result
+}
+
+// sort sorts the groups topologically based on their dependencies.
+func (b *Backupper) sort(in []*sortable) []*sortable {
+	existsMap := make(map[string]*sortable)
+	for _, g := range in {
+		existsMap[g.id] = g
+	}
+
+	var (
+		visited      = make(map[string]bool)
+		recursionMap = make(map[string]bool)
+		result       = []*sortable{}
+		dfs          func(group *sortable) bool
+	)
+
+	// topological sort with DFS
+	dfs = func(nodes *sortable) bool {
+		if recursionMap[nodes.id] {
+			b.logger.Warn("Detected cycle in group dependencies", zap.String("group_id", nodes.id))
+			return false
+		}
+
+		if visited[nodes.id] {
+			return true
+		}
+
+		visited[nodes.id] = true
+		recursionMap[nodes.id] = true
+
+		// if node has parent and exists in map
+		if m, exists := existsMap[nodes.parent]; exists {
+			if !dfs(m) {
+				// circular dependency detected
+				recursionMap[nodes.id] = false
+				return false
+			}
+		}
+
+		recursionMap[nodes.id] = false
+
+		result = append(result, nodes)
+
+		return true
+	}
+
+	for _, node := range in {
+		if !visited[node.id] {
+			if !dfs(node) {
+				return nil
+			}
+		}
+	}
+
+	return result
+}

--- a/internal/backupper/groups.go
+++ b/internal/backupper/groups.go
@@ -101,31 +101,31 @@ func (b *Backupper) sort(in []*sortable) []*sortable {
 	)
 
 	// topological sort with DFS
-	dfs = func(nodes *sortable) bool {
-		if recursionMap[nodes.id] {
-			b.logger.Warn("Detected cycle in group dependencies", zap.String("group_id", nodes.id))
+	dfs = func(node *sortable) bool {
+		if recursionMap[node.id] {
+			b.logger.Warn("Detected cycle in group dependencies", zap.String("group_id", node.id))
 			return false
 		}
 
-		if visited[nodes.id] {
+		if visited[node.id] {
 			return true
 		}
 
-		visited[nodes.id] = true
-		recursionMap[nodes.id] = true
+		visited[node.id] = true
+		recursionMap[node.id] = true
 
 		// if node has parent and exists in map
-		if m, exists := existsMap[nodes.parent]; exists {
+		if m, exists := existsMap[node.parent]; exists {
 			if !dfs(m) {
 				// circular dependency detected
-				recursionMap[nodes.id] = false
+				recursionMap[node.id] = false
 				return false
 			}
 		}
 
-		recursionMap[nodes.id] = false
+		recursionMap[node.id] = false
 
-		result = append(result, nodes)
+		result = append(result, node)
 
 		return true
 	}

--- a/internal/backupper/groups.go
+++ b/internal/backupper/groups.go
@@ -114,12 +114,14 @@ func (b *Backupper) sort(in []*sortable) []*sortable {
 		visited[node.id] = true
 		recursionMap[node.id] = true
 
-		// if node has parent and exists in map
-		if m, exists := existsMap[node.parent]; exists {
-			if !dfs(m) {
-				// circular dependency detected
-				recursionMap[node.id] = false
-				return false
+		// if node has a non-empty parent and exists in map
+		if node.parent != "" {
+			if m, exists := existsMap[node.parent]; exists {
+				if !dfs(m) {
+					// circular dependency detected
+					recursionMap[node.id] = false
+					return false
+				}
 			}
 		}
 

--- a/internal/backupper/restore.go
+++ b/internal/backupper/restore.go
@@ -29,9 +29,12 @@ func (b *Backupper) Restore(ctx context.Context, reader io.Reader) error {
 			return err
 		}
 
+		sortableGroups := b.psqlGroupsToSortable(data.Groups)
+		sorted := b.sortPSQLGroups(sortableGroups)
+
 		restorationGroups = []restorationGroup{
 			{name: "application types", data: toInsertable(data.ApplicationTypes)},
-			{name: "groups", data: toInsertable(data.Groups)},
+			{name: "groups", data: toInsertable(sorted)},
 			{name: "users", data: toInsertable(data.Users)},
 			{name: "extensions", data: toInsertable(data.Extensions)},
 			{name: "notification targets", data: toInsertable(data.NotificationTargets)},
@@ -58,9 +61,12 @@ func (b *Backupper) Restore(ctx context.Context, reader io.Reader) error {
 			return err
 		}
 
+		sortableGroups := b.crdbGroupsToSortable(data.Groups)
+		sorted := b.sortCRDBGroups(sortableGroups)
+
 		restorationGroups = []restorationGroup{
 			{name: "application types", data: toInsertable(data.ApplicationTypes)},
-			{name: "groups", data: toInsertable(data.Groups)},
+			{name: "groups", data: toInsertable(sorted)},
 			{name: "users", data: toInsertable(data.Users)},
 			{name: "extensions", data: toInsertable(data.Extensions)},
 			{name: "notification targets", data: toInsertable(data.NotificationTargets)},


### PR DESCRIPTION
The groups DB model has a self-reference (`group->approverGropup`).

This PR implements a simple topological sort to ensure that the dependencies are created before itself.