### PR TITLE
Disable `linux-386` builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,9 @@ builds:
     goos:
       - linux
       - darwin
+    ignore:
+      - goos: linux
+        goarch: '386'
     ldflags:
       - -s -w
       - -X main.version={{.Version}}


### PR DESCRIPTION
Our release [has been failing](https://github.com/metal-toolbox/governor-api/actions/runs/17687764247/job/50275959569#step:7:42) on `linux-386` because of integer overflow from one of our upstream dependencies, we're disable `linux-386` builds on release for now.