### PR TITLE
fix implement safeLogger and recoveryMiddleware

### DIFF
--- a/internal/api/recovery.go
+++ b/internal/api/recovery.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	ginzap "github.com/gin-contrib/zap"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// safeLogger wraps *zap.Logger and implements ginzap.ZapLogger.
+// It drops the raw "request" field from panic recovery log entries to prevent
+// credential leakage (e.g. Authorization / Cookie headers).
+type safeLogger struct {
+	*zap.Logger
+}
+
+// Error overrides *zap.Logger.Error, stripping any "request" field before logging.
+func (s safeLogger) Error(msg string, fields ...zap.Field) {
+	filtered := fields[:0:len(fields)]
+
+	for _, f := range fields {
+		if f.Key == "request" && f.Type == zapcore.StringType {
+			continue
+		}
+
+		filtered = append(filtered, f)
+	}
+
+	s.Logger.Error(msg, filtered...)
+}
+
+// recoveryMiddleware returns a gin.HandlerFunc that uses ginzap.RecoveryWithZap
+// with a safeLogger so the raw HTTP request dump (which includes headers) is
+// never written to the log when a panic occurs.
+func recoveryMiddleware(logger *zap.Logger) gin.HandlerFunc {
+	return ginzap.RecoveryWithZap(safeLogger{logger}, true)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -124,7 +124,7 @@ func (s *Server) setup() *gin.Engine {
 		}),
 	)
 
-	router.Use(ginzap.RecoveryWithZap(s.Conf.Logger.With(zap.String("component", "api")), true))
+	router.Use(recoveryMiddleware(s.Conf.Logger.With(zap.String("component", "api"))))
 
 	tp := otel.GetTracerProvider()
 	if tp != nil {


### PR DESCRIPTION
This pull request enhances the security of panic recovery logging in the API by ensuring that sensitive request data (such as Authorization or Cookie headers) is not written to logs when a panic occurs. It introduces a custom recovery middleware that filters out potentially sensitive information before logging.

Security improvements to panic recovery logging:

* Added a new `safeLogger` type in `internal/api/recovery.go` that wraps `*zap.Logger` and overrides the `Error` method to filter out the "request" field, preventing raw HTTP request data from being logged during panic recovery.
* Replaced the use of `ginzap.RecoveryWithZap` in `internal/api/server.go` with the new `recoveryMiddleware`, ensuring that all panic recovery logging uses the safe logger and does not leak credentials.