### PR TITLE
fix: update openapi schema

### DIFF
--- a/openapi/v1alpha1/components/schemas.yaml
+++ b/openapi/v1alpha1/components/schemas.yaml
@@ -21,6 +21,8 @@ Group:
   $ref: './schemas/groups.yaml#/Group'
 GroupMemberRequest:
   $ref: './schemas/groups.yaml#/GroupMemberRequest'
+AddUserToGroupRequest:
+  $ref: './schemas/groups.yaml#/AddUserToGroupRequest'
 GroupMember:
   $ref: './schemas/groups.yaml#/GroupMember'
 GroupMembership:

--- a/openapi/v1alpha1/components/schemas/applications.yaml
+++ b/openapi/v1alpha1/components/schemas/applications.yaml
@@ -63,7 +63,6 @@ ApplicationType:
       description: Description of the application type
     logo_url:
       type: [string, "null"]
-      format: uri
       description: URL to the logo image for this application type
     created_at:
       type: string
@@ -128,7 +127,6 @@ ApplicationTypeRequest:
       examples: ["Database services that require access management"]
     logo_url:
       type: [string, "null"]
-      format: uri
       description: URL to the logo image for this application type
       examples: ["https://example.com/logos/database.png"]
   required:

--- a/openapi/v1alpha1/components/schemas/groups.yaml
+++ b/openapi/v1alpha1/components/schemas/groups.yaml
@@ -87,6 +87,22 @@ Group:
     - created_at
     - updated_at
 
+AddUserToGroupRequest:
+  type: object
+  properties:
+    is_admin:
+      type: [boolean, "null"]
+      description: Whether admin privileges are being requested
+      default: false
+    expires_at:
+      type: [string, "null"]
+      format: date-time
+      description: When the membership should expire (optional)
+    admin_expires_at:
+      type: [string, "null"]
+      format: date-time
+      description: When the admin role should expire (optional)
+
 GroupMemberRequest:
   type: object
   description: |

--- a/openapi/v1alpha1/components/schemas/groups.yaml
+++ b/openapi/v1alpha1/components/schemas/groups.yaml
@@ -309,7 +309,7 @@ AuthenticatedUserGroup:
     note:
       type: [string, "null"]
       description: Additional notes about the group
-    approver_group_id:
+    approver_group:
       type: [string, "null"]
       format: uuid
       description: ID of the group that approves membership requests
@@ -321,6 +321,13 @@ AuthenticatedUserGroup:
       type: [string, "null"]
       format: date-time
       description: Timestamp when the group was last updated
+    deleted_at:
+      type: [string, "null"]
+      format: date-time
+      description: Timestamp when the group was deleted (if applicable)
+    metadata:
+      type: object
+      description: Arbitrary metadata associated with the group
     organizations:
       oneOf:
         - type: array

--- a/openapi/v1alpha1/components/schemas/users.yaml
+++ b/openapi/v1alpha1/components/schemas/users.yaml
@@ -12,7 +12,6 @@ User:
       description: Name of the user
     email:
       type: string
-      format: email
       description: Email address of the user
     external_id:
       type: [string, "null"]
@@ -21,7 +20,6 @@ User:
       type: 
         - string
         - 'null'
-      format: uri
       description: URL to user's profile image
     created_at:
       type: string
@@ -59,14 +57,12 @@ UserProfile:
       description: Name of the user (optional, can be null)
     email:
       type: string
-      format: email
       description: Email address of the user
     external_id:
       type: [string, "null"]
       description: External ID for the user from the identity provider
     avatar_url:
       type: [string, "null"]
-      format: uri
       description: URL to user's profile image
     status:
       type: [string, "null"]
@@ -148,7 +144,6 @@ AuthenticatedUserRequestPayload:
   properties:
     avatar_url:
       type: [string, "null"]
-      format: uri
       description: URL to the user's avatar image
     github_username:
       type: [string, "null"]
@@ -166,7 +161,6 @@ UserCreateRequest:
       examples: ["Jane Smith"]
     email:
       type: string
-      format: email
       description: Email address of the user
       examples: ["jane.smith@example.com"]
     external_id:
@@ -175,7 +169,6 @@ UserCreateRequest:
       examples: ["auth0|123456789"]
     avatar_url:
       type: [string, "null"]
-      format: uri
       description: URL to the user's avatar image
       examples: ["https://example.com/avatars/jane.jpg"]
     github_username:
@@ -210,11 +203,9 @@ UserUpdateRequest:
       description: Full name of the user
     email:
       type: [string, "null"]
-      format: email
       description: Email address of the user
     avatar_url:
       type: [string, "null"]
-      format: uri
       description: URL to the user's avatar image
     github_username:
       type: [string, "null"]

--- a/openapi/v1alpha1/paths/authenticated-user.yaml
+++ b/openapi/v1alpha1/paths/authenticated-user.yaml
@@ -15,7 +15,7 @@ user-groups:
               oneOf:
                 - type: array
                   items:
-                    $ref: '../components/schemas.yaml#/Group'
+                    $ref: '../components/schemas.yaml#/AuthenticatedUserGroup'
                 - type: 'null'
       '401':
         $ref: '../components/responses.yaml#/Unauthorized'

--- a/openapi/v1alpha1/paths/groups.yaml
+++ b/openapi/v1alpha1/paths/groups.yaml
@@ -453,7 +453,7 @@ groups-id-users-uid:
       content:
         application/json:
           schema:
-            $ref: '../components/schemas.yaml#/GroupMemberRequest'
+            $ref: '../components/schemas.yaml#/AddUserToGroupRequest'
     responses:
       '204':
         description: User successfully added to group


### PR DESCRIPTION
This pull request introduces several updates to the OpenAPI schemas for users, groups, and applications. The main changes include the addition of a new `AddUserToGroupRequest` schema, enhancements to the `AuthenticatedUserGroup` schema, and the removal of strict format constraints from several string fields (such as `email` and `uri`). These changes aim to improve flexibility and support for additional group membership scenarios.

**Group Membership Enhancements:**

* Added a new `AddUserToGroupRequest` schema, allowing for optional admin privileges and expiration dates when adding a user to a group. References to this schema were added in both `schemas.yaml` and `groups.yaml`, and it replaces `GroupMemberRequest` in the group user addition endpoint. [[1]](diffhunk://#diff-f1325242d9796fdeb7724757133ca2df042858f0904d5abba807ca43b5536ecbR24-R25) [[2]](diffhunk://#diff-ebf968bab585b3f8363ca503bb1c9ab4960de74d6917d3f23ee9a5f83715b1c2R90-R105) [[3]](diffhunk://#diff-d758b14ded8a04b705f4793ba839b3e62a318c57b9bee02bb0cc543fae3a9a68L456-R456)
* Updated the `AuthenticatedUserGroup` schema to include new fields: `deleted_at` (timestamp for group deletion) and `metadata` (arbitrary metadata).
* Changed the `approver_group_id` field in `AuthenticatedUserGroup` to `approver_group` for clarity.
* Updated the response for the authenticated user's groups endpoint to use the `AuthenticatedUserGroup` schema instead of `Group`.

**Schema Format Relaxation:**

* Removed the `format: email` and `format: uri` constraints from several fields in the `User`, `UserProfile`, `UserCreateRequest`, `UserUpdateRequest`, and `ApplicationType` schemas to allow for more flexible input. [[1]](diffhunk://#diff-e403f0571cf227e4b28cbd592305f122ff60624a52a4be50e2923f5da5e21601L15) [[2]](diffhunk://#diff-e403f0571cf227e4b28cbd592305f122ff60624a52a4be50e2923f5da5e21601L24) [[3]](diffhunk://#diff-e403f0571cf227e4b28cbd592305f122ff60624a52a4be50e2923f5da5e21601L62-L69) [[4]](diffhunk://#diff-e403f0571cf227e4b28cbd592305f122ff60624a52a4be50e2923f5da5e21601L151) [[5]](diffhunk://#diff-e403f0571cf227e4b28cbd592305f122ff60624a52a4be50e2923f5da5e21601L169) [[6]](diffhunk://#diff-e403f0571cf227e4b28cbd592305f122ff60624a52a4be50e2923f5da5e21601L178) [[7]](diffhunk://#diff-e403f0571cf227e4b28cbd592305f122ff60624a52a4be50e2923f5da5e21601L213-L217) [[8]](diffhunk://#diff-b53600667147c673d45eb891160f99c54588766767a150b0831b1041a2d340acL66) [[9]](diffhunk://#diff-b53600667147c673d45eb891160f99c54588766767a150b0831b1041a2d340acL131)

These changes collectively enhance the API's flexibility and support for advanced group membership and user scenarios.