### PR TITLE
refactor(client): support oauth2.TokenSource via http transport

### DIFF
--- a/pkg/client/applications_test.go
+++ b/pkg/client/applications_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 
 	"github.com/metal-toolbox/governor-api/pkg/api/v1alpha1"
 )
@@ -103,14 +102,14 @@ func TestClient_Applications(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		httpClient HTTPDoer
-		want       []*v1alpha1.Application
-		wantErr    bool
+		name      string
+		transport http.RoundTripper
+		want      []*v1alpha1.Application
+		wantErr   bool
 	}{
 		{
 			name: "example request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testApplicationsResponse,
 				statusCode: http.StatusOK,
@@ -119,7 +118,7 @@ func TestClient_Applications(t *testing.T) {
 		},
 		{
 			name: "example request status accepted",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testApplicationsResponse,
 				statusCode: http.StatusOK,
@@ -128,7 +127,7 @@ func TestClient_Applications(t *testing.T) {
 		},
 		{
 			name: "non-success",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusInternalServerError,
 			},
@@ -136,7 +135,7 @@ func TestClient_Applications(t *testing.T) {
 		},
 		{
 			name: "bad json response",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusOK,
 				resp:       []byte(`{`),
@@ -148,11 +147,9 @@ func TestClient_Applications(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.transport},
 			}
 
 			got, err := c.Applications(context.TODO())
@@ -177,60 +174,48 @@ func TestClient_Application(t *testing.T) {
 		return &resp
 	}
 
-	type fields struct {
-		httpClient HTTPDoer
-	}
-
 	tests := []struct {
-		name    string
-		fields  fields
-		id      string
-		want    *v1alpha1.Application
-		wantErr bool
+		name      string
+		transport http.RoundTripper
+		id        string
+		want      *v1alpha1.Application
+		wantErr   bool
 	}{
 		{
 			name: "example request",
-			fields: fields{
-				httpClient: &mockHTTPDoer{
-					t:          t,
-					resp:       testApplicationResponse,
-					statusCode: http.StatusOK,
-				},
+			transport: &mockTransport{
+				t:          t,
+				resp:       testApplicationResponse,
+				statusCode: http.StatusOK,
 			},
 			id:   "14af17ea-6b60-4dd0-8ed4-f16d86756849",
 			want: testResp(testApplicationResponse),
 		},
 		{
 			name: "non-success",
-			fields: fields{
-				httpClient: &mockHTTPDoer{
-					t:          t,
-					statusCode: http.StatusInternalServerError,
-				},
+			transport: &mockTransport{
+				t:          t,
+				statusCode: http.StatusInternalServerError,
 			},
 			id:      "14af17ea-6b60-4dd0-8ed4-f16d86756849",
 			wantErr: true,
 		},
 		{
 			name: "bad json response",
-			fields: fields{
-				httpClient: &mockHTTPDoer{
-					t:          t,
-					statusCode: http.StatusOK,
-					resp:       []byte(`{`),
-				},
+			transport: &mockTransport{
+				t:          t,
+				statusCode: http.StatusOK,
+				resp:       []byte(`{`),
 			},
 			id:      "14af17ea-6b60-4dd0-8ed4-f16d86756849",
 			wantErr: true,
 		},
 		{
 			name: "missing id in request",
-			fields: fields{
-				httpClient: &mockHTTPDoer{
-					t:          t,
-					resp:       testApplicationResponse,
-					statusCode: http.StatusOK,
-				},
+			transport: &mockTransport{
+				t:          t,
+				resp:       testApplicationResponse,
+				statusCode: http.StatusOK,
 			},
 			wantErr: true,
 		},
@@ -239,11 +224,9 @@ func TestClient_Application(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.transport},
 			}
 
 			got, err := c.Application(context.TODO(), tt.id)
@@ -260,15 +243,15 @@ func TestClient_Application(t *testing.T) {
 
 func TestClient_AddGroupToApplication(t *testing.T) {
 	tests := []struct {
-		name       string
-		groupID    string
-		appID      string
-		httpClient HTTPDoer
-		wantErr    bool
+		name      string
+		groupID   string
+		appID     string
+		transport http.RoundTripper
+		wantErr   bool
 	}{
 		{
 			name: "example ok request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -278,7 +261,7 @@ func TestClient_AddGroupToApplication(t *testing.T) {
 		},
 		{
 			name: "example accepted request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusAccepted,
@@ -288,7 +271,7 @@ func TestClient_AddGroupToApplication(t *testing.T) {
 		},
 		{
 			name: "example no content request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusNoContent,
@@ -298,7 +281,7 @@ func TestClient_AddGroupToApplication(t *testing.T) {
 		},
 		{
 			name: "not found",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusNotFound,
 			},
@@ -308,7 +291,7 @@ func TestClient_AddGroupToApplication(t *testing.T) {
 		},
 		{
 			name: "non-success",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusInternalServerError,
 			},
@@ -318,7 +301,7 @@ func TestClient_AddGroupToApplication(t *testing.T) {
 		},
 		{
 			name: "missing groupID in request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -328,7 +311,7 @@ func TestClient_AddGroupToApplication(t *testing.T) {
 		},
 		{
 			name: "missing appID in request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -341,11 +324,9 @@ func TestClient_AddGroupToApplication(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.transport},
 			}
 
 			err := c.AddGroupToApplication(context.TODO(), tt.groupID, tt.appID)
@@ -361,15 +342,15 @@ func TestClient_AddGroupToApplication(t *testing.T) {
 
 func TestClient_RemoveGroupFromApplication(t *testing.T) {
 	tests := []struct {
-		name       string
-		groupID    string
-		appID      string
-		httpClient HTTPDoer
-		wantErr    bool
+		name      string
+		groupID   string
+		appID     string
+		transport http.RoundTripper
+		wantErr   bool
 	}{
 		{
 			name: "example ok request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -379,7 +360,7 @@ func TestClient_RemoveGroupFromApplication(t *testing.T) {
 		},
 		{
 			name: "example accepted request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusAccepted,
@@ -389,7 +370,7 @@ func TestClient_RemoveGroupFromApplication(t *testing.T) {
 		},
 		{
 			name: "example no content request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusNoContent,
@@ -399,7 +380,7 @@ func TestClient_RemoveGroupFromApplication(t *testing.T) {
 		},
 		{
 			name: "not found",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusNotFound,
 			},
@@ -409,7 +390,7 @@ func TestClient_RemoveGroupFromApplication(t *testing.T) {
 		},
 		{
 			name: "non-success",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusInternalServerError,
 			},
@@ -419,7 +400,7 @@ func TestClient_RemoveGroupFromApplication(t *testing.T) {
 		},
 		{
 			name: "missing groupID in request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -429,7 +410,7 @@ func TestClient_RemoveGroupFromApplication(t *testing.T) {
 		},
 		{
 			name: "missing appID in request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -442,11 +423,9 @@ func TestClient_RemoveGroupFromApplication(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.transport},
 			}
 
 			err := c.RemoveGroupFromApplication(context.TODO(), tt.groupID, tt.appID)
@@ -471,14 +450,14 @@ func TestClient_ApplicationTypes(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		httpClient HTTPDoer
-		want       []*v1alpha1.ApplicationType
-		wantErr    bool
+		name      string
+		transport http.RoundTripper
+		want      []*v1alpha1.ApplicationType
+		wantErr   bool
 	}{
 		{
 			name: "example request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testApplicationTypesResponse,
 				statusCode: http.StatusOK,
@@ -487,7 +466,7 @@ func TestClient_ApplicationTypes(t *testing.T) {
 		},
 		{
 			name: "example request status accepted",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testApplicationTypesResponse,
 				statusCode: http.StatusOK,
@@ -496,7 +475,7 @@ func TestClient_ApplicationTypes(t *testing.T) {
 		},
 		{
 			name: "non-success",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusInternalServerError,
 			},
@@ -504,7 +483,7 @@ func TestClient_ApplicationTypes(t *testing.T) {
 		},
 		{
 			name: "bad json response",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusOK,
 				resp:       []byte(`{`),
@@ -516,11 +495,9 @@ func TestClient_ApplicationTypes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.transport},
 			}
 
 			got, err := c.ApplicationTypes(context.TODO())
@@ -545,60 +522,48 @@ func TestClient_ApplicationType(t *testing.T) {
 		return &resp
 	}
 
-	type fields struct {
-		httpClient HTTPDoer
-	}
-
 	tests := []struct {
-		name    string
-		fields  fields
-		id      string
-		want    *v1alpha1.ApplicationType
-		wantErr bool
+		name      string
+		transport http.RoundTripper
+		id        string
+		want      *v1alpha1.ApplicationType
+		wantErr   bool
 	}{
 		{
 			name: "example request",
-			fields: fields{
-				httpClient: &mockHTTPDoer{
-					t:          t,
-					resp:       testApplicationTypeResponse,
-					statusCode: http.StatusOK,
-				},
+			transport: &mockTransport{
+				t:          t,
+				resp:       testApplicationTypeResponse,
+				statusCode: http.StatusOK,
 			},
 			id:   "bed9edd4-b44a-4dc6-ba41-902138f37bd6",
 			want: testResp(testApplicationTypeResponse),
 		},
 		{
 			name: "non-success",
-			fields: fields{
-				httpClient: &mockHTTPDoer{
-					t:          t,
-					statusCode: http.StatusInternalServerError,
-				},
+			transport: &mockTransport{
+				t:          t,
+				statusCode: http.StatusInternalServerError,
 			},
 			id:      "bed9edd4-b44a-4dc6-ba41-902138f37bd6",
 			wantErr: true,
 		},
 		{
 			name: "bad json response",
-			fields: fields{
-				httpClient: &mockHTTPDoer{
-					t:          t,
-					statusCode: http.StatusOK,
-					resp:       []byte(`{`),
-				},
+			transport: &mockTransport{
+				t:          t,
+				statusCode: http.StatusOK,
+				resp:       []byte(`{`),
 			},
 			id:      "bed9edd4-b44a-4dc6-ba41-902138f37bd6",
 			wantErr: true,
 		},
 		{
 			name: "missing id in request",
-			fields: fields{
-				httpClient: &mockHTTPDoer{
-					t:          t,
-					resp:       testApplicationTypeResponse,
-					statusCode: http.StatusOK,
-				},
+			transport: &mockTransport{
+				t:          t,
+				resp:       testApplicationTypeResponse,
+				statusCode: http.StatusOK,
 			},
 			wantErr: true,
 		},
@@ -607,11 +572,9 @@ func TestClient_ApplicationType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.transport},
 			}
 
 			got, err := c.ApplicationType(context.TODO(), tt.id)

--- a/pkg/client/extension_resource_definitions_test.go
+++ b/pkg/client/extension_resource_definitions_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/metal-toolbox/governor-api/pkg/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -80,7 +79,7 @@ func TestClient_ExtensionResourceDefinitions(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -93,7 +92,7 @@ func TestClient_ExtensionResourceDefinitions(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testERDsResponse),
 					statusCode: http.StatusOK,
@@ -105,7 +104,7 @@ func TestClient_ExtensionResourceDefinitions(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -116,7 +115,7 @@ func TestClient_ExtensionResourceDefinitions(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -127,7 +126,7 @@ func TestClient_ExtensionResourceDefinitions(t *testing.T) {
 		{
 			name: "null response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`null`),
@@ -139,7 +138,7 @@ func TestClient_ExtensionResourceDefinitions(t *testing.T) {
 		{
 			name: "extension not found",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"extension not found: sql: no rows in result set"}`),
@@ -154,11 +153,9 @@ func TestClient_ExtensionResourceDefinitions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.ExtensionResourceDefinitions(context.TODO(), "test-extension-1", false)
 
@@ -187,7 +184,7 @@ func TestClient_ExtensionResourceDefinition(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient *mockHTTPDoer
+		transport *mockTransport
 	}
 
 	tests := []struct {
@@ -207,7 +204,7 @@ func TestClient_ExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testERDResponse),
 					statusCode: http.StatusOK,
@@ -222,7 +219,7 @@ func TestClient_ExtensionResourceDefinition(t *testing.T) {
 			extensionID: "test-extension-1",
 			erdID:       "a82a34a5-db1f-464f-af9c-76086e79f715",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testERDResponse),
 					statusCode: http.StatusOK,
@@ -238,7 +235,7 @@ func TestClient_ExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -252,7 +249,7 @@ func TestClient_ExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -266,7 +263,7 @@ func TestClient_ExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -280,7 +277,7 @@ func TestClient_ExtensionResourceDefinition(t *testing.T) {
 			erdID:       "",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -294,7 +291,7 @@ func TestClient_ExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"extension does not exist"}`),
@@ -309,7 +306,7 @@ func TestClient_ExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"ERD does not exist"}`),
@@ -323,11 +320,9 @@ func TestClient_ExtensionResourceDefinition(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.ExtensionResourceDefinition(context.TODO(), tt.extensionID, tt.erdID, tt.erdVersion, false)
 
@@ -343,7 +338,7 @@ func TestClient_ExtensionResourceDefinition(t *testing.T) {
 			assert.Equal(t, tt.expected, got)
 
 			if tt.expectedPath != "" {
-				assert.Equal(t, tt.expectedPath, tt.fields.httpClient.Request().URL.Path)
+				assert.Equal(t, tt.expectedPath, tt.fields.transport.Request().URL.Path)
 			}
 		})
 	}
@@ -362,7 +357,7 @@ func TestClient_CreateExtensionResourceDefinition(t *testing.T) {
 	enabled := true
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -378,7 +373,7 @@ func TestClient_CreateExtensionResourceDefinition(t *testing.T) {
 			name:        "example request",
 			extensionID: "test-extension-1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testERDResponse),
 					statusCode: http.StatusOK,
@@ -401,7 +396,7 @@ func TestClient_CreateExtensionResourceDefinition(t *testing.T) {
 			name:        "example request status accepted",
 			extensionID: "test-extension-1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testERDResponse),
 					statusCode: http.StatusAccepted,
@@ -424,7 +419,7 @@ func TestClient_CreateExtensionResourceDefinition(t *testing.T) {
 			name:        "non-success",
 			extensionID: "test-extension-1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -437,7 +432,7 @@ func TestClient_CreateExtensionResourceDefinition(t *testing.T) {
 			name:        "bad json response",
 			extensionID: "test-extension-1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -450,7 +445,7 @@ func TestClient_CreateExtensionResourceDefinition(t *testing.T) {
 			name:        "extension ID missing",
 			extensionID: "",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testERDResponse),
 					statusCode: http.StatusOK,
@@ -464,7 +459,7 @@ func TestClient_CreateExtensionResourceDefinition(t *testing.T) {
 			name:        "extension not found",
 			extensionID: "test-extension-1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(`{"error":"extension not found: sql: no rows in result set"}`),
 					statusCode: http.StatusNotFound,
@@ -479,11 +474,9 @@ func TestClient_CreateExtensionResourceDefinition(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.CreateExtensionResourceDefinition(context.TODO(), tt.extensionID, tt.req)
 
@@ -512,7 +505,7 @@ func TestClient_UpdateExtensionResourceDefinition(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient *mockHTTPDoer
+		transport *mockTransport
 	}
 
 	tests := []struct {
@@ -534,7 +527,7 @@ func TestClient_UpdateExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testERDResponse),
 					statusCode: http.StatusOK,
@@ -552,7 +545,7 @@ func TestClient_UpdateExtensionResourceDefinition(t *testing.T) {
 			extensionID: "test-extension-1",
 			erdID:       "a82a34a5-db1f-464f-af9c-76086e79f715",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testERDResponse),
 					statusCode: http.StatusOK,
@@ -571,7 +564,7 @@ func TestClient_UpdateExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testERDResponse),
 					statusCode: http.StatusAccepted,
@@ -590,7 +583,7 @@ func TestClient_UpdateExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -608,7 +601,7 @@ func TestClient_UpdateExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -625,7 +618,7 @@ func TestClient_UpdateExtensionResourceDefinition(t *testing.T) {
 			erdID:      "erd-1",
 			erdVersion: "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(""),
 					statusCode: http.StatusOK,
@@ -642,7 +635,7 @@ func TestClient_UpdateExtensionResourceDefinition(t *testing.T) {
 			extensionID: "test-extension-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(""),
 					statusCode: http.StatusOK,
@@ -660,7 +653,7 @@ func TestClient_UpdateExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(`{"error":"extension does not exist"}`),
 					statusCode: http.StatusNotFound,
@@ -678,7 +671,7 @@ func TestClient_UpdateExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(`{"error":"ERD does not exist"}`),
 					statusCode: http.StatusNotFound,
@@ -695,11 +688,9 @@ func TestClient_UpdateExtensionResourceDefinition(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.UpdateExtensionResourceDefinition(context.TODO(), tt.extensionID, tt.erdID, tt.erdVersion, tt.req)
 
@@ -715,7 +706,7 @@ func TestClient_UpdateExtensionResourceDefinition(t *testing.T) {
 			assert.Equal(t, tt.expected, got)
 
 			if tt.expectedPath != "" {
-				assert.Equal(t, tt.expectedPath, tt.fields.httpClient.Request().URL.Path)
+				assert.Equal(t, tt.expectedPath, tt.fields.transport.Request().URL.Path)
 			}
 		})
 	}
@@ -723,7 +714,7 @@ func TestClient_UpdateExtensionResourceDefinition(t *testing.T) {
 
 func TestClient_DeleteExtensionResourceDefinition(t *testing.T) {
 	type fields struct {
-		httpClient *mockHTTPDoer
+		transport *mockTransport
 	}
 
 	tests := []struct {
@@ -742,7 +733,7 @@ func TestClient_DeleteExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testERDResponse),
 					statusCode: http.StatusOK,
@@ -756,7 +747,7 @@ func TestClient_DeleteExtensionResourceDefinition(t *testing.T) {
 			extensionID: "test-extension-1",
 			erdID:       "a82a34a5-db1f-464f-af9c-76086e79f715",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testERDResponse),
 					statusCode: http.StatusOK,
@@ -771,7 +762,7 @@ func TestClient_DeleteExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -784,7 +775,7 @@ func TestClient_DeleteExtensionResourceDefinition(t *testing.T) {
 			erdID:      "erd-1",
 			erdVersion: "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -796,7 +787,7 @@ func TestClient_DeleteExtensionResourceDefinition(t *testing.T) {
 			name:        "missing ERD id",
 			extensionID: "test-extension-1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -810,7 +801,7 @@ func TestClient_DeleteExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"extension does not exist"}`),
@@ -825,7 +816,7 @@ func TestClient_DeleteExtensionResourceDefinition(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"ERD does not exist"}`),
@@ -839,11 +830,9 @@ func TestClient_DeleteExtensionResourceDefinition(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			err := c.DeleteExtensionResourceDefinition(context.TODO(), tt.extensionID, tt.erdID, tt.erdVersion)
 
@@ -858,7 +847,7 @@ func TestClient_DeleteExtensionResourceDefinition(t *testing.T) {
 			assert.NoError(t, err)
 
 			if tt.expectedPath != "" {
-				assert.Equal(t, tt.expectedPath, tt.fields.httpClient.Request().URL.Path)
+				assert.Equal(t, tt.expectedPath, tt.fields.transport.Request().URL.Path)
 			}
 		})
 	}

--- a/pkg/client/extensions_test.go
+++ b/pkg/client/extensions_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/metal-toolbox/governor-api/pkg/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -62,7 +61,7 @@ func TestClient_Extensions(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -74,7 +73,7 @@ func TestClient_Extensions(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionsResponse),
 					statusCode: http.StatusOK,
@@ -85,7 +84,7 @@ func TestClient_Extensions(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -95,7 +94,7 @@ func TestClient_Extensions(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -106,7 +105,7 @@ func TestClient_Extensions(t *testing.T) {
 		{
 			name: "null response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`null`),
@@ -120,11 +119,9 @@ func TestClient_Extensions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.Extensions(context.TODO(), false)
 
@@ -150,7 +147,7 @@ func TestClient_Extension(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -164,7 +161,7 @@ func TestClient_Extension(t *testing.T) {
 			name: "example request",
 			id:   "test-extension-1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResponse),
 					statusCode: http.StatusOK,
@@ -176,7 +173,7 @@ func TestClient_Extension(t *testing.T) {
 			name: "non-success",
 			id:   "test-extension-1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -187,7 +184,7 @@ func TestClient_Extension(t *testing.T) {
 			name: "bad json response",
 			id:   "test-extension-1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -199,7 +196,7 @@ func TestClient_Extension(t *testing.T) {
 			name: "missing id",
 			id:   "test-extension-1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -211,11 +208,9 @@ func TestClient_Extension(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.Extension(context.TODO(), tt.id, false)
 
@@ -243,7 +238,7 @@ func TestClient_CreateExtension(t *testing.T) {
 	enabled := true
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -256,7 +251,7 @@ func TestClient_CreateExtension(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResponse),
 					statusCode: http.StatusOK,
@@ -272,7 +267,7 @@ func TestClient_CreateExtension(t *testing.T) {
 		{
 			name: "example request status accepted",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResponse),
 					statusCode: http.StatusAccepted,
@@ -288,7 +283,7 @@ func TestClient_CreateExtension(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -303,7 +298,7 @@ func TestClient_CreateExtension(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -321,11 +316,9 @@ func TestClient_CreateExtension(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.CreateExtension(context.TODO(), tt.req)
 
@@ -351,7 +344,7 @@ func TestClient_UpdateExtension(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -365,7 +358,7 @@ func TestClient_UpdateExtension(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResponse),
 					statusCode: http.StatusOK,
@@ -380,7 +373,7 @@ func TestClient_UpdateExtension(t *testing.T) {
 		{
 			name: "example request status accepted",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResponse),
 					statusCode: http.StatusAccepted,
@@ -395,7 +388,7 @@ func TestClient_UpdateExtension(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -409,7 +402,7 @@ func TestClient_UpdateExtension(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -424,7 +417,7 @@ func TestClient_UpdateExtension(t *testing.T) {
 		{
 			name: "missing id",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResponse),
 					statusCode: http.StatusOK,
@@ -440,11 +433,9 @@ func TestClient_UpdateExtension(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.UpdateExtension(context.TODO(), tt.id, tt.req)
 
@@ -470,7 +461,7 @@ func TestClient_DeleteExtension(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -484,7 +475,7 @@ func TestClient_DeleteExtension(t *testing.T) {
 			name: "example request",
 			id:   "test-extension-1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResponse),
 					statusCode: http.StatusOK,
@@ -496,7 +487,7 @@ func TestClient_DeleteExtension(t *testing.T) {
 			name: "non-success",
 			id:   "test-extension-1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -506,7 +497,7 @@ func TestClient_DeleteExtension(t *testing.T) {
 		{
 			name: "missing id",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -518,11 +509,9 @@ func TestClient_DeleteExtension(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			err := c.DeleteExtension(context.TODO(), tt.id)
 

--- a/pkg/client/governor.go
+++ b/pkg/client/governor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/url"
-	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -21,24 +20,12 @@ const (
 
 var tracer = otel.GetTracerProvider().Tracer("http-client.governor-api/v1alpha1")
 
-// HTTPDoer implements the standard http.Client interface.
-type HTTPDoer interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
-// Tokener implements the token interface
-type Tokener interface {
-	Token(ctx context.Context) (*oauth2.Token, error)
-}
-
 // Client is a governor API client
 type Client struct {
-	url                    string
-	clientCredentialConfig Tokener
-	logger                 *zap.Logger
-	token                  *oauth2.Token
-	httpClient             HTTPDoer
-	authMux                sync.Mutex
+	url        string
+	logger     *zap.Logger
+	httpClient *http.Client
+	ts         oauth2.TokenSource
 }
 
 // URL returns the governor url
@@ -57,9 +44,18 @@ func WithURL(u string) Option {
 }
 
 // WithClientCredentialConfig sets the oauth client credential config
+//
+// Deprecated: use WithTokenSource instead
 func WithClientCredentialConfig(c *clientcredentials.Config) Option {
 	return func(r *Client) {
-		r.clientCredentialConfig = c
+		r.ts = c.TokenSource(context.Background())
+	}
+}
+
+// WithTokenSource set the oauth token source
+func WithTokenSource(ts oauth2.TokenSource) Option {
+	return func(r *Client) {
+		r.ts = ts
 	}
 }
 
@@ -71,7 +67,7 @@ func WithLogger(l *zap.Logger) Option {
 }
 
 // WithHTTPClient overrides the default http client
-func WithHTTPClient(c HTTPDoer) Option {
+func WithHTTPClient(c *http.Client) Option {
 	return func(r *Client) {
 		r.httpClient = c
 	}
@@ -90,49 +86,21 @@ func NewClient(opts ...Option) (*Client, error) {
 		opt(&client)
 	}
 
-	t, err := client.auth(context.TODO())
-	if err != nil {
-		return nil, err
+	if client.ts != nil {
+		if _, err := client.ts.Token(); err != nil {
+			return nil, err
+		}
+
+		client.httpClient.Transport = &oauth2.Transport{
+			Source: client.ts,
+			Base:   client.httpClient.Transport,
+		}
 	}
-
-	client.authMux.Lock()
-	defer client.authMux.Unlock()
-
-	client.token = t
 
 	return &client, nil
 }
 
-func (c *Client) auth(ctx context.Context) (*oauth2.Token, error) {
-	c.logger.Debug("authenticating governor client", zap.Any("clientcredentialconfig", c.clientCredentialConfig))
-	return c.clientCredentialConfig.Token(ctx)
-}
-
-func (c *Client) refreshAuth(ctx context.Context) error {
-	if c.token != nil && !time.Now().After(c.token.Expiry) {
-		return nil
-	}
-
-	t, err := c.auth(ctx)
-	if err != nil {
-		return err
-	}
-
-	c.authMux.Lock()
-	defer c.authMux.Unlock()
-
-	c.token = t
-
-	c.logger.Debug("refreshing governor client authentication")
-
-	return nil
-}
-
 func (c *Client) newGovernorRequest(ctx context.Context, method, u string) (*http.Request, error) {
-	if err := c.refreshAuth(ctx); err != nil {
-		return nil, err
-	}
-
 	c.logger.Debug("parsing url", zap.String("url", u))
 
 	queryURL, err := url.Parse(u)
@@ -146,9 +114,6 @@ func (c *Client) newGovernorRequest(ctx context.Context, method, u string) (*htt
 	if err != nil {
 		return nil, err
 	}
-
-	bearer := "Bearer " + c.token.AccessToken
-	req.Header.Add("Authorization", bearer)
 
 	return req, nil
 }

--- a/pkg/client/governor.go
+++ b/pkg/client/governor.go
@@ -87,14 +87,19 @@ func NewClient(opts ...Option) (*Client, error) {
 	}
 
 	if client.ts != nil {
-		if _, err := client.ts.Token(); err != nil {
+		ts := oauth2.ReuseTokenSource(nil, client.ts)
+
+		if _, err := ts.Token(); err != nil {
 			return nil, err
 		}
 
-		client.httpClient.Transport = &oauth2.Transport{
-			Source: client.ts,
-			Base:   client.httpClient.Transport,
+		c := *client.httpClient
+		c.Transport = &oauth2.Transport{
+			Source: ts,
+			Base:   c.Transport,
 		}
+
+		client.httpClient = &c
 	}
 
 	return &client, nil

--- a/pkg/client/governor_test.go
+++ b/pkg/client/governor_test.go
@@ -7,27 +7,22 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 )
 
-type mockHTTPDoer struct {
+// mockTransport implements [http.RoundTripper]
+var _ http.RoundTripper = &mockTransport{}
+
+type mockTransport struct {
 	t          *testing.T
 	statusCode int
 	resp       []byte
 	request    *http.Request
 }
 
-type mockTokener struct {
-	t     *testing.T
-	err   error
-	token *oauth2.Token
-}
-
-func (m *mockHTTPDoer) Do(r *http.Request) (*http.Response, error) {
+func (m *mockTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	resp := http.Response{
 		StatusCode: m.statusCode,
 	}
@@ -38,30 +33,22 @@ func (m *mockHTTPDoer) Do(r *http.Request) (*http.Response, error) {
 	return &resp, nil
 }
 
-func (m *mockHTTPDoer) Request() *http.Request {
+func (m *mockTransport) Request() *http.Request {
 	return m.request
 }
 
-func (m *mockTokener) Token(_ context.Context) (*oauth2.Token, error) {
-	if m.err != nil {
-		return nil, m.err
-	}
+// mockMultiTransport implements [http.RoundTripper], returning a different
+// response on each successive call.
+var _ http.RoundTripper = &mockMultiTransport{}
 
-	if m.token != nil {
-		return m.token, nil
-	}
-
-	return &oauth2.Token{Expiry: time.Now().Add(5 * time.Second)}, nil
-}
-
-type mockHTTPMultiDoer struct {
+type mockMultiTransport struct {
 	t           *testing.T
 	statusCode  int
 	resp        [][]byte
 	timesCalled int
 }
 
-func (m *mockHTTPMultiDoer) Do(_ *http.Request) (*http.Response, error) {
+func (m *mockMultiTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	resp := http.Response{
 		StatusCode: m.statusCode,
 	}
@@ -74,39 +61,26 @@ func (m *mockHTTPMultiDoer) Do(_ *http.Request) (*http.Response, error) {
 }
 
 func TestClient_newGovernorRequest(t *testing.T) {
-	testReq := func(m, u, t string) *http.Request {
+	testReq := func(m, u string) *http.Request {
 		queryURL, _ := url.Parse(u)
 
 		req, _ := http.NewRequestWithContext(context.TODO(), m, queryURL.String(), nil)
-		req.Header.Add("Authorization", "Bearer "+t)
 
 		return req
 	}
 
-	type fields struct {
-		url   string
-		token *oauth2.Token
-	}
-
 	tests := []struct {
 		name    string
-		fields  fields
-		method  string
 		url     string
+		method  string
 		want    *http.Request
 		wantErr bool
 	}{
 		{
-			name: "example GET request",
-			fields: fields{
-				token: &oauth2.Token{
-					AccessToken: "topSekret!!!!!11111",
-					Expiry:      time.Now().Add(5 * time.Second),
-				},
-			},
+			name:   "example GET request",
 			method: http.MethodGet,
 			url:    "https://foo.example.com/tax",
-			want:   testReq(http.MethodGet, "https://foo.example.com/tax", "topSekret!!!!!11111"),
+			want:   testReq(http.MethodGet, "https://foo.example.com/tax"),
 		},
 		{
 			name:    "example bad method",
@@ -124,10 +98,7 @@ func TestClient_newGovernorRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    tt.fields.url,
-				logger:                 zap.NewNop(),
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  tt.fields.token,
+				logger: zap.NewNop(),
 			}
 
 			got, err := c.newGovernorRequest(context.TODO(), tt.method, tt.url)

--- a/pkg/client/groups_test.go
+++ b/pkg/client/groups_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 
 	"github.com/metal-toolbox/governor-api/pkg/api/v1alpha1"
 )
@@ -122,7 +121,7 @@ func TestClient_Groups(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -134,7 +133,7 @@ func TestClient_Groups(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testGroupsResponse,
 					statusCode: http.StatusOK,
@@ -145,7 +144,7 @@ func TestClient_Groups(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -155,7 +154,7 @@ func TestClient_Groups(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -168,11 +167,9 @@ func TestClient_Groups(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.Groups(context.TODO())
 
@@ -198,7 +195,7 @@ func TestClient_Group(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -211,7 +208,7 @@ func TestClient_Group(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testGroupResponse,
 					statusCode: http.StatusOK,
@@ -223,7 +220,7 @@ func TestClient_Group(t *testing.T) {
 		{
 			name: "not found",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 				},
@@ -234,7 +231,7 @@ func TestClient_Group(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -245,7 +242,7 @@ func TestClient_Group(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -257,7 +254,7 @@ func TestClient_Group(t *testing.T) {
 		{
 			name: "missing id in request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testGroupResponse,
 					statusCode: http.StatusOK,
@@ -269,11 +266,9 @@ func TestClient_Group(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.Group(context.TODO(), tt.id, false)
 
@@ -299,7 +294,7 @@ func TestClient_GroupMembers(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -313,7 +308,7 @@ func TestClient_GroupMembers(t *testing.T) {
 			name: "example request",
 			id:   "8923e54d-0df6-407a-832d-2917915a3ff7",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testGroupMembersResponse,
 					statusCode: http.StatusOK,
@@ -324,7 +319,7 @@ func TestClient_GroupMembers(t *testing.T) {
 		{
 			name: "missing id in request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testGroupMembersResponse,
 					statusCode: http.StatusOK,
@@ -336,7 +331,7 @@ func TestClient_GroupMembers(t *testing.T) {
 			name: "non-success",
 			id:   "8923e54d-0df6-407a-832d-2917915a3ff7",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -347,7 +342,7 @@ func TestClient_GroupMembers(t *testing.T) {
 			name: "bad json response",
 			id:   "8923e54d-0df6-407a-832d-2917915a3ff7",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -360,11 +355,9 @@ func TestClient_GroupMembers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.GroupMembers(context.TODO(), tt.id)
 
@@ -390,7 +383,7 @@ func TestClient_GroupMemberRequests(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -404,7 +397,7 @@ func TestClient_GroupMemberRequests(t *testing.T) {
 			name: "example request",
 			id:   "8923e54d-0df6-407a-832d-2917915a3ff7",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testGroupMemberRequestsResponse,
 					statusCode: http.StatusOK,
@@ -415,7 +408,7 @@ func TestClient_GroupMemberRequests(t *testing.T) {
 		{
 			name: "missing id in request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testGroupMemberRequestsResponse,
 					statusCode: http.StatusOK,
@@ -427,7 +420,7 @@ func TestClient_GroupMemberRequests(t *testing.T) {
 			name: "non-success",
 			id:   "8923e54d-0df6-407a-832d-2917915a3ff7",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -438,7 +431,7 @@ func TestClient_GroupMemberRequests(t *testing.T) {
 			name: "bad json response",
 			id:   "8923e54d-0df6-407a-832d-2917915a3ff7",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -451,11 +444,9 @@ func TestClient_GroupMemberRequests(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.GroupMemberRequests(context.TODO(), tt.id)
 
@@ -481,7 +472,7 @@ func TestClient_CreateGroup(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -494,7 +485,7 @@ func TestClient_CreateGroup(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testGroupResponse,
 					statusCode: http.StatusOK,
@@ -510,7 +501,7 @@ func TestClient_CreateGroup(t *testing.T) {
 		{
 			name: "example request status accepted",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testGroupResponse,
 					statusCode: http.StatusAccepted,
@@ -526,7 +517,7 @@ func TestClient_CreateGroup(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -541,7 +532,7 @@ func TestClient_CreateGroup(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -559,11 +550,9 @@ func TestClient_CreateGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.CreateGroup(context.TODO(), tt.req)
 
@@ -580,14 +569,14 @@ func TestClient_CreateGroup(t *testing.T) {
 
 func TestClient_DeleteGroup(t *testing.T) {
 	tests := []struct {
-		name       string
-		id         string
-		httpClient HTTPDoer
-		wantErr    bool
+		name      string
+		id        string
+		transport http.RoundTripper
+		wantErr   bool
 	}{
 		{
 			name: "example ok request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -596,7 +585,7 @@ func TestClient_DeleteGroup(t *testing.T) {
 		},
 		{
 			name: "example accepted request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusAccepted,
@@ -605,7 +594,7 @@ func TestClient_DeleteGroup(t *testing.T) {
 		},
 		{
 			name: "not found",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusNotFound,
 			},
@@ -614,7 +603,7 @@ func TestClient_DeleteGroup(t *testing.T) {
 		},
 		{
 			name: "non-success",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusInternalServerError,
 			},
@@ -623,7 +612,7 @@ func TestClient_DeleteGroup(t *testing.T) {
 		},
 		{
 			name: "missing id in request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -634,11 +623,9 @@ func TestClient_DeleteGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.transport},
 			}
 			err := c.DeleteGroup(context.TODO(), tt.id)
 
@@ -654,15 +641,15 @@ func TestClient_DeleteGroup(t *testing.T) {
 
 func TestClient_AddGroupMember(t *testing.T) {
 	tests := []struct {
-		name       string
-		httpClient HTTPDoer
-		groupID    string
-		userID     string
-		wantErr    bool
+		name      string
+		transport http.RoundTripper
+		groupID   string
+		userID    string
+		wantErr   bool
 	}{
 		{
 			name: "example ok request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -672,7 +659,7 @@ func TestClient_AddGroupMember(t *testing.T) {
 		},
 		{
 			name: "example accepted request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusAccepted,
@@ -682,7 +669,7 @@ func TestClient_AddGroupMember(t *testing.T) {
 		},
 		{
 			name: "example no content request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusNoContent,
@@ -692,7 +679,7 @@ func TestClient_AddGroupMember(t *testing.T) {
 		},
 		{
 			name: "not found",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusNotFound,
 			},
@@ -702,7 +689,7 @@ func TestClient_AddGroupMember(t *testing.T) {
 		},
 		{
 			name: "non-success",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusInternalServerError,
 			},
@@ -712,7 +699,7 @@ func TestClient_AddGroupMember(t *testing.T) {
 		},
 		{
 			name: "missing groupID in request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -722,7 +709,7 @@ func TestClient_AddGroupMember(t *testing.T) {
 		},
 		{
 			name: "missing orgID in request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -734,11 +721,9 @@ func TestClient_AddGroupMember(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.transport},
 			}
 			err := c.AddGroupMember(context.TODO(), tt.groupID, tt.userID, false)
 
@@ -754,15 +739,15 @@ func TestClient_AddGroupMember(t *testing.T) {
 
 func TestClient_RemoveGroupMember(t *testing.T) {
 	tests := []struct {
-		name       string
-		httpClient HTTPDoer
-		groupID    string
-		userID     string
-		wantErr    bool
+		name      string
+		transport http.RoundTripper
+		groupID   string
+		userID    string
+		wantErr   bool
 	}{
 		{
 			name: "example ok request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -772,7 +757,7 @@ func TestClient_RemoveGroupMember(t *testing.T) {
 		},
 		{
 			name: "example accepted request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusAccepted,
@@ -782,7 +767,7 @@ func TestClient_RemoveGroupMember(t *testing.T) {
 		},
 		{
 			name: "example no content request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusNoContent,
@@ -792,7 +777,7 @@ func TestClient_RemoveGroupMember(t *testing.T) {
 		},
 		{
 			name: "not found",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusNotFound,
 			},
@@ -802,7 +787,7 @@ func TestClient_RemoveGroupMember(t *testing.T) {
 		},
 		{
 			name: "non-success",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusInternalServerError,
 			},
@@ -812,7 +797,7 @@ func TestClient_RemoveGroupMember(t *testing.T) {
 		},
 		{
 			name: "missing groupID in request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -822,7 +807,7 @@ func TestClient_RemoveGroupMember(t *testing.T) {
 		},
 		{
 			name: "missing orgID in request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -834,11 +819,9 @@ func TestClient_RemoveGroupMember(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.transport},
 			}
 			err := c.RemoveGroupMember(context.TODO(), tt.groupID, tt.userID)
 
@@ -854,15 +837,15 @@ func TestClient_RemoveGroupMember(t *testing.T) {
 
 func TestClient_AddGroupToOrganization(t *testing.T) {
 	tests := []struct {
-		name       string
-		groupID    string
-		orgID      string
-		httpClient HTTPDoer
-		wantErr    bool
+		name      string
+		groupID   string
+		orgID     string
+		transport http.RoundTripper
+		wantErr   bool
 	}{
 		{
 			name: "example ok request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -872,7 +855,7 @@ func TestClient_AddGroupToOrganization(t *testing.T) {
 		},
 		{
 			name: "example accepted request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusAccepted,
@@ -882,7 +865,7 @@ func TestClient_AddGroupToOrganization(t *testing.T) {
 		},
 		{
 			name: "example no content request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusNoContent,
@@ -892,7 +875,7 @@ func TestClient_AddGroupToOrganization(t *testing.T) {
 		},
 		{
 			name: "not found",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusNotFound,
 			},
@@ -902,7 +885,7 @@ func TestClient_AddGroupToOrganization(t *testing.T) {
 		},
 		{
 			name: "non-success",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusInternalServerError,
 			},
@@ -912,7 +895,7 @@ func TestClient_AddGroupToOrganization(t *testing.T) {
 		},
 		{
 			name: "missing groupID in request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -922,7 +905,7 @@ func TestClient_AddGroupToOrganization(t *testing.T) {
 		},
 		{
 			name: "missing orgID in request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -934,11 +917,9 @@ func TestClient_AddGroupToOrganization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.transport},
 			}
 			err := c.AddGroupToOrganization(context.TODO(), tt.groupID, tt.orgID)
 
@@ -954,15 +935,15 @@ func TestClient_AddGroupToOrganization(t *testing.T) {
 
 func TestClient_RemoveGroupFromOrganization(t *testing.T) {
 	tests := []struct {
-		name       string
-		groupID    string
-		orgID      string
-		httpClient HTTPDoer
-		wantErr    bool
+		name      string
+		groupID   string
+		orgID     string
+		transport http.RoundTripper
+		wantErr   bool
 	}{
 		{
 			name: "example ok request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -972,7 +953,7 @@ func TestClient_RemoveGroupFromOrganization(t *testing.T) {
 		},
 		{
 			name: "example accepted request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusAccepted,
@@ -982,7 +963,7 @@ func TestClient_RemoveGroupFromOrganization(t *testing.T) {
 		},
 		{
 			name: "example no content request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusNoContent,
@@ -992,7 +973,7 @@ func TestClient_RemoveGroupFromOrganization(t *testing.T) {
 		},
 		{
 			name: "not found",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusNotFound,
 			},
@@ -1002,7 +983,7 @@ func TestClient_RemoveGroupFromOrganization(t *testing.T) {
 		},
 		{
 			name: "non-success",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusInternalServerError,
 			},
@@ -1012,7 +993,7 @@ func TestClient_RemoveGroupFromOrganization(t *testing.T) {
 		},
 		{
 			name: "missing groupID in request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -1022,7 +1003,7 @@ func TestClient_RemoveGroupFromOrganization(t *testing.T) {
 		},
 		{
 			name: "missing orgID in request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testGroupResponse,
 				statusCode: http.StatusOK,
@@ -1034,11 +1015,9 @@ func TestClient_RemoveGroupFromOrganization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.transport},
 			}
 			err := c.RemoveGroupFromOrganization(context.TODO(), tt.groupID, tt.orgID)
 
@@ -1063,7 +1042,7 @@ func TestClient_GroupMembersAll(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -1075,7 +1054,7 @@ func TestClient_GroupMembersAll(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testGroupMembersAllResponse,
 					statusCode: http.StatusOK,
@@ -1086,7 +1065,7 @@ func TestClient_GroupMembersAll(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -1096,7 +1075,7 @@ func TestClient_GroupMembersAll(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -1109,11 +1088,9 @@ func TestClient_GroupMembersAll(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.GroupMembersAll(context.TODO(), false)
 
@@ -1139,7 +1116,7 @@ func TestClient_GroupMemberRequestsAll(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -1151,7 +1128,7 @@ func TestClient_GroupMemberRequestsAll(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testGroupMemberRequestsResponse,
 					statusCode: http.StatusOK,
@@ -1162,7 +1139,7 @@ func TestClient_GroupMemberRequestsAll(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -1172,7 +1149,7 @@ func TestClient_GroupMemberRequestsAll(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -1185,11 +1162,9 @@ func TestClient_GroupMemberRequestsAll(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.GroupMembershipRequestsAll(context.TODO(), false)
 

--- a/pkg/client/hierarchies_test.go
+++ b/pkg/client/hierarchies_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/metal-toolbox/governor-api/pkg/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 )
 
 func TestClient_GroupHierarchies(t *testing.T) {
@@ -24,7 +23,7 @@ func TestClient_GroupHierarchies(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -36,7 +35,7 @@ func TestClient_GroupHierarchies(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testGroupHierarchiesResponse,
 					statusCode: http.StatusOK,
@@ -47,7 +46,7 @@ func TestClient_GroupHierarchies(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -58,11 +57,9 @@ func TestClient_GroupHierarchies(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.GroupHierarchies(context.TODO())
 
@@ -88,7 +85,7 @@ func TestClient_MemberGroups(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -101,7 +98,7 @@ func TestClient_MemberGroups(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testMemberGroupsResponse,
 					statusCode: http.StatusOK,
@@ -113,7 +110,7 @@ func TestClient_MemberGroups(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -124,7 +121,7 @@ func TestClient_MemberGroups(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -136,7 +133,7 @@ func TestClient_MemberGroups(t *testing.T) {
 		{
 			name: "missing id in request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -147,11 +144,9 @@ func TestClient_MemberGroups(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.MemberGroups(context.TODO(), tt.id)
 
@@ -168,7 +163,7 @@ func TestClient_MemberGroups(t *testing.T) {
 
 func TestClient_AddMemberGroup(t *testing.T) {
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -182,7 +177,7 @@ func TestClient_AddMemberGroup(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testMemberGroupsResponse,
 					statusCode: http.StatusOK,
@@ -195,7 +190,7 @@ func TestClient_AddMemberGroup(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -208,7 +203,7 @@ func TestClient_AddMemberGroup(t *testing.T) {
 		{
 			name: "missing fields in request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -219,11 +214,9 @@ func TestClient_AddMemberGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			err := c.AddMemberGroup(context.TODO(), tt.parentGroupID, tt.memberGroupID, tt.expiresAt)
 
@@ -239,7 +232,7 @@ func TestClient_AddMemberGroup(t *testing.T) {
 
 func TestClient_UpdateMemberGroup(t *testing.T) {
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -253,7 +246,7 @@ func TestClient_UpdateMemberGroup(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testMemberGroupsResponse,
 					statusCode: http.StatusOK,
@@ -266,7 +259,7 @@ func TestClient_UpdateMemberGroup(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -279,7 +272,7 @@ func TestClient_UpdateMemberGroup(t *testing.T) {
 		{
 			name: "missing fields in request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -290,11 +283,9 @@ func TestClient_UpdateMemberGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			err := c.UpdateMemberGroup(context.TODO(), tt.parentGroupID, tt.memberGroupID, tt.expiresAt)
 
@@ -310,7 +301,7 @@ func TestClient_UpdateMemberGroup(t *testing.T) {
 
 func TestClient_DeleteMemberGroup(t *testing.T) {
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -323,7 +314,7 @@ func TestClient_DeleteMemberGroup(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testMemberGroupsResponse,
 					statusCode: http.StatusOK,
@@ -335,7 +326,7 @@ func TestClient_DeleteMemberGroup(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -347,7 +338,7 @@ func TestClient_DeleteMemberGroup(t *testing.T) {
 		{
 			name: "missing fields in request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -358,11 +349,9 @@ func TestClient_DeleteMemberGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			err := c.DeleteMemberGroup(context.TODO(), tt.parentGroupID, tt.memberGroupID)
 

--- a/pkg/client/notification_preferences_test.go
+++ b/pkg/client/notification_preferences_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/metal-toolbox/governor-api/pkg/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -70,7 +69,7 @@ func TestClient_NotificationPreferences(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -83,7 +82,7 @@ func TestClient_NotificationPreferences(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationPreferencesResponse),
 					statusCode: http.StatusOK,
@@ -95,7 +94,7 @@ func TestClient_NotificationPreferences(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -106,7 +105,7 @@ func TestClient_NotificationPreferences(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -118,7 +117,7 @@ func TestClient_NotificationPreferences(t *testing.T) {
 		{
 			name: "missing user ID",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -130,11 +129,9 @@ func TestClient_NotificationPreferences(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.NotificationPreferences(context.TODO(), "")
 

--- a/pkg/client/notification_targets_test.go
+++ b/pkg/client/notification_targets_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/metal-toolbox/governor-api/pkg/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -69,7 +68,7 @@ func TestClient_NotificationTargets(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -81,7 +80,7 @@ func TestClient_NotificationTargets(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTargetsResponse),
 					statusCode: http.StatusOK,
@@ -92,7 +91,7 @@ func TestClient_NotificationTargets(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -102,7 +101,7 @@ func TestClient_NotificationTargets(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -113,7 +112,7 @@ func TestClient_NotificationTargets(t *testing.T) {
 		{
 			name: "null response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`null`),
@@ -127,11 +126,9 @@ func TestClient_NotificationTargets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.NotificationTargets(context.TODO(), false)
 
@@ -157,7 +154,7 @@ func TestClient_NotificationTarget(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -171,7 +168,7 @@ func TestClient_NotificationTarget(t *testing.T) {
 			name: "example request",
 			id:   "71e05156-ee15-4f99-ba34-94f38ecc5438",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTargetResponse),
 					statusCode: http.StatusOK,
@@ -183,7 +180,7 @@ func TestClient_NotificationTarget(t *testing.T) {
 			name: "non-success",
 			id:   "71e05156-ee15-4f99-ba34-94f38ecc5438",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -194,7 +191,7 @@ func TestClient_NotificationTarget(t *testing.T) {
 			name: "bad json response",
 			id:   "71e05156-ee15-4f99-ba34-94f38ecc5438",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -206,7 +203,7 @@ func TestClient_NotificationTarget(t *testing.T) {
 			name: "missing id",
 			id:   "71e05156-ee15-4f99-ba34-94f38ecc5438",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -218,11 +215,9 @@ func TestClient_NotificationTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.NotificationTarget(context.TODO(), tt.id, false)
 
@@ -250,7 +245,7 @@ func TestClient_CreateNotificationTarget(t *testing.T) {
 	enabled := true
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -263,7 +258,7 @@ func TestClient_CreateNotificationTarget(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTargetResponse),
 					statusCode: http.StatusOK,
@@ -279,7 +274,7 @@ func TestClient_CreateNotificationTarget(t *testing.T) {
 		{
 			name: "example request status accepted",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTargetResponse),
 					statusCode: http.StatusAccepted,
@@ -295,7 +290,7 @@ func TestClient_CreateNotificationTarget(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -310,7 +305,7 @@ func TestClient_CreateNotificationTarget(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -328,11 +323,9 @@ func TestClient_CreateNotificationTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.CreateNotificationTarget(context.TODO(), tt.req)
 
@@ -358,7 +351,7 @@ func TestClient_UpdateNotificationTarget(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -372,7 +365,7 @@ func TestClient_UpdateNotificationTarget(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTargetResponse),
 					statusCode: http.StatusOK,
@@ -388,7 +381,7 @@ func TestClient_UpdateNotificationTarget(t *testing.T) {
 		{
 			name: "example request status accepted",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTargetResponse),
 					statusCode: http.StatusAccepted,
@@ -404,7 +397,7 @@ func TestClient_UpdateNotificationTarget(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -419,7 +412,7 @@ func TestClient_UpdateNotificationTarget(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -435,7 +428,7 @@ func TestClient_UpdateNotificationTarget(t *testing.T) {
 		{
 			name: "missing id",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTargetResponse),
 					statusCode: http.StatusOK,
@@ -452,11 +445,9 @@ func TestClient_UpdateNotificationTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.UpdateNotificationTarget(context.TODO(), tt.id, tt.req)
 
@@ -482,7 +473,7 @@ func TestClient_DeleteNotificationTarget(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -496,7 +487,7 @@ func TestClient_DeleteNotificationTarget(t *testing.T) {
 			name: "example request",
 			id:   "71e05156-ee15-4f99-ba34-94f38ecc5438",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTargetResponse),
 					statusCode: http.StatusOK,
@@ -508,7 +499,7 @@ func TestClient_DeleteNotificationTarget(t *testing.T) {
 			name: "non-success",
 			id:   "71e05156-ee15-4f99-ba34-94f38ecc5438",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -518,7 +509,7 @@ func TestClient_DeleteNotificationTarget(t *testing.T) {
 		{
 			name: "missing id",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -530,11 +521,9 @@ func TestClient_DeleteNotificationTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			err := c.DeleteNotificationTarget(context.TODO(), tt.id)
 

--- a/pkg/client/notification_types_test.go
+++ b/pkg/client/notification_types_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/metal-toolbox/governor-api/pkg/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -69,7 +68,7 @@ func TestClient_NotificationTypes(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -81,7 +80,7 @@ func TestClient_NotificationTypes(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTypesResponse),
 					statusCode: http.StatusOK,
@@ -92,7 +91,7 @@ func TestClient_NotificationTypes(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -102,7 +101,7 @@ func TestClient_NotificationTypes(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -113,7 +112,7 @@ func TestClient_NotificationTypes(t *testing.T) {
 		{
 			name: "null response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`null`),
@@ -127,11 +126,9 @@ func TestClient_NotificationTypes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.NotificationTypes(context.TODO(), false)
 
@@ -157,7 +154,7 @@ func TestClient_NotificationType(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -171,7 +168,7 @@ func TestClient_NotificationType(t *testing.T) {
 			name: "example request",
 			id:   "21037d41-53ee-4144-b39b-6b2eb5761a30",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTypeResponse),
 					statusCode: http.StatusOK,
@@ -183,7 +180,7 @@ func TestClient_NotificationType(t *testing.T) {
 			name: "non-success",
 			id:   "21037d41-53ee-4144-b39b-6b2eb5761a30",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -194,7 +191,7 @@ func TestClient_NotificationType(t *testing.T) {
 			name: "bad json response",
 			id:   "21037d41-53ee-4144-b39b-6b2eb5761a30",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -206,7 +203,7 @@ func TestClient_NotificationType(t *testing.T) {
 			name: "missing id",
 			id:   "21037d41-53ee-4144-b39b-6b2eb5761a30",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -218,11 +215,9 @@ func TestClient_NotificationType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.NotificationType(context.TODO(), tt.id, false)
 
@@ -248,7 +243,7 @@ func TestClient_CreateNotificationType(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -261,7 +256,7 @@ func TestClient_CreateNotificationType(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTypeResponse),
 					statusCode: http.StatusOK,
@@ -276,7 +271,7 @@ func TestClient_CreateNotificationType(t *testing.T) {
 		{
 			name: "example request status accepted",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTypeResponse),
 					statusCode: http.StatusAccepted,
@@ -291,7 +286,7 @@ func TestClient_CreateNotificationType(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -305,7 +300,7 @@ func TestClient_CreateNotificationType(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -322,11 +317,9 @@ func TestClient_CreateNotificationType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.CreateNotificationType(context.TODO(), tt.req)
 
@@ -352,7 +345,7 @@ func TestClient_UpdateNotificationType(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -366,7 +359,7 @@ func TestClient_UpdateNotificationType(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTypeResponse),
 					statusCode: http.StatusOK,
@@ -382,7 +375,7 @@ func TestClient_UpdateNotificationType(t *testing.T) {
 		{
 			name: "example request status accepted",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTypeResponse),
 					statusCode: http.StatusAccepted,
@@ -398,7 +391,7 @@ func TestClient_UpdateNotificationType(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -413,7 +406,7 @@ func TestClient_UpdateNotificationType(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -429,7 +422,7 @@ func TestClient_UpdateNotificationType(t *testing.T) {
 		{
 			name: "missing id",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTypeResponse),
 					statusCode: http.StatusOK,
@@ -446,11 +439,9 @@ func TestClient_UpdateNotificationType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.UpdateNotificationType(context.TODO(), tt.id, tt.req)
 
@@ -476,7 +467,7 @@ func TestClient_DeleteNotificationType(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -490,7 +481,7 @@ func TestClient_DeleteNotificationType(t *testing.T) {
 			name: "example request",
 			id:   "21037d41-53ee-4144-b39b-6b2eb5761a30",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testNotificationTypeResponse),
 					statusCode: http.StatusOK,
@@ -502,7 +493,7 @@ func TestClient_DeleteNotificationType(t *testing.T) {
 			name: "non-success",
 			id:   "21037d41-53ee-4144-b39b-6b2eb5761a30",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -512,7 +503,7 @@ func TestClient_DeleteNotificationType(t *testing.T) {
 		{
 			name: "missing id",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -524,11 +515,9 @@ func TestClient_DeleteNotificationType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			err := c.DeleteNotificationType(context.TODO(), tt.id)
 

--- a/pkg/client/organizations_test.go
+++ b/pkg/client/organizations_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 )
 
 var (
@@ -247,7 +246,7 @@ func TestClient_Organization(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -260,7 +259,7 @@ func TestClient_Organization(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testOrganizationResponse,
 					statusCode: http.StatusOK,
@@ -272,7 +271,7 @@ func TestClient_Organization(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -283,7 +282,7 @@ func TestClient_Organization(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -295,7 +294,7 @@ func TestClient_Organization(t *testing.T) {
 		{
 			name: "missing id in request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testOrganizationResponse,
 					statusCode: http.StatusOK,
@@ -307,11 +306,9 @@ func TestClient_Organization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.Organization(context.TODO(), tt.id)
 
@@ -337,14 +334,14 @@ func TestClient_Organizations(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		httpClient HTTPDoer
-		want       []*v1alpha1.Organization
-		wantErr    bool
+		name      string
+		transport http.RoundTripper
+		want      []*v1alpha1.Organization
+		wantErr   bool
 	}{
 		{
 			name: "example request",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testOrganizationsResponse,
 				statusCode: http.StatusOK,
@@ -353,7 +350,7 @@ func TestClient_Organizations(t *testing.T) {
 		},
 		{
 			name: "example request status accepted",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				resp:       testOrganizationsResponse,
 				statusCode: http.StatusOK,
@@ -362,7 +359,7 @@ func TestClient_Organizations(t *testing.T) {
 		},
 		{
 			name: "non-success",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusInternalServerError,
 			},
@@ -370,7 +367,7 @@ func TestClient_Organizations(t *testing.T) {
 		},
 		{
 			name: "bad json response",
-			httpClient: &mockHTTPDoer{
+			transport: &mockTransport{
 				t:          t,
 				statusCode: http.StatusOK,
 				resp:       []byte(`{`),
@@ -382,11 +379,9 @@ func TestClient_Organizations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.transport},
 			}
 			got, err := c.Organizations(context.TODO())
 
@@ -412,7 +407,7 @@ func TestClient_OrganizationGroups(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -425,7 +420,7 @@ func TestClient_OrganizationGroups(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testOrganizationGroupsResponse,
 					statusCode: http.StatusOK,
@@ -437,7 +432,7 @@ func TestClient_OrganizationGroups(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -448,7 +443,7 @@ func TestClient_OrganizationGroups(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -462,11 +457,9 @@ func TestClient_OrganizationGroups(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.OrganizationGroups(context.TODO(), tt.id)
 

--- a/pkg/client/sys_extension_resources_test.go
+++ b/pkg/client/sys_extension_resources_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/metal-toolbox/governor-api/pkg/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -87,7 +86,7 @@ func TestClient_SystemExtensionResources(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -100,7 +99,7 @@ func TestClient_SystemExtensionResources(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResourcesResponse),
 					statusCode: http.StatusOK,
@@ -112,7 +111,7 @@ func TestClient_SystemExtensionResources(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -123,7 +122,7 @@ func TestClient_SystemExtensionResources(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -134,7 +133,7 @@ func TestClient_SystemExtensionResources(t *testing.T) {
 		{
 			name: "null response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`null`),
@@ -146,7 +145,7 @@ func TestClient_SystemExtensionResources(t *testing.T) {
 		{
 			name: "extension not found",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"extension does not exist: sql: no rows in result set"}`),
@@ -161,11 +160,9 @@ func TestClient_SystemExtensionResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.SystemExtensionResources(
 				context.TODO(), "test-extension-1", "some-resources", "v1", false, nil,
@@ -196,7 +193,7 @@ func TestClient_SystemExtensionResource(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient *mockHTTPDoer
+		transport *mockTransport
 	}
 
 	tests := []struct {
@@ -217,7 +214,7 @@ func TestClient_SystemExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResourceResponse),
 					statusCode: http.StatusOK,
@@ -232,7 +229,7 @@ func TestClient_SystemExtensionResource(t *testing.T) {
 			erdID:       "a82a34a5-db1f-464f-af9c-76086e79f715",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResourceResponse),
 					statusCode: http.StatusOK,
@@ -248,7 +245,7 @@ func TestClient_SystemExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -263,7 +260,7 @@ func TestClient_SystemExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -278,7 +275,7 @@ func TestClient_SystemExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -293,7 +290,7 @@ func TestClient_SystemExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -307,7 +304,7 @@ func TestClient_SystemExtensionResource(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -322,7 +319,7 @@ func TestClient_SystemExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"extension does not exist"}`),
@@ -338,7 +335,7 @@ func TestClient_SystemExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"ERD does not exist"}`),
@@ -352,11 +349,9 @@ func TestClient_SystemExtensionResource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.SystemExtensionResource(
 				context.TODO(), tt.extensionID, tt.erdID, tt.erdVersion,
@@ -379,7 +374,7 @@ func TestClient_SystemExtensionResource(t *testing.T) {
 
 func TestClient_DeleteSystemExtensionResource(t *testing.T) {
 	type fields struct {
-		httpClient *mockHTTPDoer
+		transport *mockTransport
 	}
 
 	tests := []struct {
@@ -399,7 +394,7 @@ func TestClient_DeleteSystemExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResourceResponse),
 					statusCode: http.StatusOK,
@@ -414,7 +409,7 @@ func TestClient_DeleteSystemExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -428,7 +423,7 @@ func TestClient_DeleteSystemExtensionResource(t *testing.T) {
 			erdVersion: "v1alpha1",
 			resourceID: "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -441,7 +436,7 @@ func TestClient_DeleteSystemExtensionResource(t *testing.T) {
 			extensionID: "test-extension-1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -455,7 +450,7 @@ func TestClient_DeleteSystemExtensionResource(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -470,7 +465,7 @@ func TestClient_DeleteSystemExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"extension does not exist"}`),
@@ -486,7 +481,7 @@ func TestClient_DeleteSystemExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"ERD does not exist"}`),
@@ -500,11 +495,9 @@ func TestClient_DeleteSystemExtensionResource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			err := c.DeleteSystemExtensionResource(context.TODO(), tt.extensionID, tt.erdID, tt.erdVersion, tt.resourceID)
 

--- a/pkg/client/user_extension_resources_test.go
+++ b/pkg/client/user_extension_resources_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/metal-toolbox/governor-api/pkg/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 )
 
 func TestClient_UserExtensionResources(t *testing.T) {
@@ -23,7 +22,7 @@ func TestClient_UserExtensionResources(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -36,7 +35,7 @@ func TestClient_UserExtensionResources(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResourcesResponse),
 					statusCode: http.StatusOK,
@@ -48,7 +47,7 @@ func TestClient_UserExtensionResources(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -59,7 +58,7 @@ func TestClient_UserExtensionResources(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -70,7 +69,7 @@ func TestClient_UserExtensionResources(t *testing.T) {
 		{
 			name: "null response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`null`),
@@ -82,7 +81,7 @@ func TestClient_UserExtensionResources(t *testing.T) {
 		{
 			name: "extension not found",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"extension not found: sql: no rows in result set"}`),
@@ -95,7 +94,7 @@ func TestClient_UserExtensionResources(t *testing.T) {
 		{
 			name: "user not found",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"user does not exist: sql: no rows in result set"}`),
@@ -110,11 +109,9 @@ func TestClient_UserExtensionResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.UserExtensionResources(
 				context.TODO(), "user-1", "test-extension-1", "some-resources", "v1", false, nil,
@@ -145,7 +142,7 @@ func TestClient_UserExtensionResource(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient *mockHTTPDoer
+		transport *mockTransport
 	}
 
 	tests := []struct {
@@ -168,7 +165,7 @@ func TestClient_UserExtensionResource(t *testing.T) {
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResourceResponse),
 					statusCode: http.StatusOK,
@@ -184,7 +181,7 @@ func TestClient_UserExtensionResource(t *testing.T) {
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResourceResponse),
 					statusCode: http.StatusOK,
@@ -201,7 +198,7 @@ func TestClient_UserExtensionResource(t *testing.T) {
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -217,7 +214,7 @@ func TestClient_UserExtensionResource(t *testing.T) {
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -233,7 +230,7 @@ func TestClient_UserExtensionResource(t *testing.T) {
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -249,7 +246,7 @@ func TestClient_UserExtensionResource(t *testing.T) {
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -264,7 +261,7 @@ func TestClient_UserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -280,7 +277,7 @@ func TestClient_UserExtensionResource(t *testing.T) {
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			userID:      "",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -296,7 +293,7 @@ func TestClient_UserExtensionResource(t *testing.T) {
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"extension does not exist"}`),
@@ -313,7 +310,7 @@ func TestClient_UserExtensionResource(t *testing.T) {
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"ERD does not exist"}`),
@@ -330,7 +327,7 @@ func TestClient_UserExtensionResource(t *testing.T) {
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"extension resource does not exist"}`),
@@ -347,7 +344,7 @@ func TestClient_UserExtensionResource(t *testing.T) {
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"user does not exist"}`),
@@ -361,11 +358,9 @@ func TestClient_UserExtensionResource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.UserExtensionResource(
 				context.TODO(), tt.userID, tt.extensionID, tt.erdID, tt.erdVersion,
@@ -397,7 +392,7 @@ func TestClient_CreateUserExtensionResource(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -419,7 +414,7 @@ func TestClient_CreateUserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResourceResponse),
 					statusCode: http.StatusCreated,
@@ -436,7 +431,7 @@ func TestClient_CreateUserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResourceResponse),
 					statusCode: http.StatusAccepted,
@@ -453,7 +448,7 @@ func TestClient_CreateUserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -469,7 +464,7 @@ func TestClient_CreateUserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusCreated,
 					resp:       []byte(`{`),
@@ -485,7 +480,7 @@ func TestClient_CreateUserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResourceResponse),
 					statusCode: http.StatusCreated,
@@ -502,7 +497,7 @@ func TestClient_CreateUserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResourceResponse),
 					statusCode: http.StatusCreated,
@@ -519,7 +514,7 @@ func TestClient_CreateUserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			userID:      "",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResourceResponse),
 					statusCode: http.StatusCreated,
@@ -536,7 +531,7 @@ func TestClient_CreateUserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(`{"error":"extension does not exist: sql: no rows in result set"}`),
 					statusCode: http.StatusNotFound,
@@ -553,7 +548,7 @@ func TestClient_CreateUserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			userID:      "f7c1c9f5-6c7d-4d6e-8d7e-9c7a3a9b5f0d",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(`{"error":"user does not exist: sql: no rows in result set"}`),
 					statusCode: http.StatusNotFound,
@@ -568,11 +563,9 @@ func TestClient_CreateUserExtensionResource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.CreateUserExtensionResource(
 				context.TODO(), tt.userID, tt.extensionID, tt.erdID, tt.erdVersion, tt.req,
@@ -603,7 +596,7 @@ func TestClient_UpdateUserExtensionResource(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient *mockHTTPDoer
+		transport *mockTransport
 	}
 
 	tests := []struct {
@@ -627,7 +620,7 @@ func TestClient_UpdateUserExtensionResource(t *testing.T) {
 			userID:      "e8f5f7c8-6d4a-4c7d-9a5b-9c9c8d7e6f5a",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResourceResponse),
 					statusCode: http.StatusOK,
@@ -645,7 +638,7 @@ func TestClient_UpdateUserExtensionResource(t *testing.T) {
 			userID:      "e8f5f7c8-6d4a-4c7d-9a5b-9c9c8d7e6f5a",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResourceResponse),
 					statusCode: http.StatusAccepted,
@@ -663,7 +656,7 @@ func TestClient_UpdateUserExtensionResource(t *testing.T) {
 			userID:      "e8f5f7c8-6d4a-4c7d-9a5b-9c9c8d7e6f5a",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -680,7 +673,7 @@ func TestClient_UpdateUserExtensionResource(t *testing.T) {
 			userID:      "e8f5f7c8-6d4a-4c7d-9a5b-9c9c8d7e6f5a",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -696,7 +689,7 @@ func TestClient_UpdateUserExtensionResource(t *testing.T) {
 			userID:     "e8f5f7c8-6d4a-4c7d-9a5b-9c9c8d7e6f5a",
 			resourceID: "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(""),
 					statusCode: http.StatusOK,
@@ -713,7 +706,7 @@ func TestClient_UpdateUserExtensionResource(t *testing.T) {
 			userID:      "e8f5f7c8-6d4a-4c7d-9a5b-9c9c8d7e6f5a",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(""),
 					statusCode: http.StatusOK,
@@ -730,7 +723,7 @@ func TestClient_UpdateUserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			userID:      "e8f5f7c8-6d4a-4c7d-9a5b-9c9c8d7e6f5a",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(""),
 					statusCode: http.StatusOK,
@@ -743,7 +736,7 @@ func TestClient_UpdateUserExtensionResource(t *testing.T) {
 		{
 			name: "missing user id",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(""),
 					statusCode: http.StatusOK,
@@ -765,7 +758,7 @@ func TestClient_UpdateUserExtensionResource(t *testing.T) {
 			userID:      "e8f5f7c8-6d4a-4c7d-9a5b-9c9c8d7e6f5a",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(`{"error":"extension does not exist"}`),
 					statusCode: http.StatusNotFound,
@@ -783,7 +776,7 @@ func TestClient_UpdateUserExtensionResource(t *testing.T) {
 			userID:      "e8f5f7c8-6d4a-4c7d-9a5b-9c9c8d7e6f5a",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(`{"error":"ERD does not exist"}`),
 					statusCode: http.StatusNotFound,
@@ -802,7 +795,7 @@ func TestClient_UpdateUserExtensionResource(t *testing.T) {
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			req:         testExtensionResourcePayload,
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(`{"error":"user does not exist"}`),
 					statusCode: http.StatusNotFound,
@@ -816,11 +809,9 @@ func TestClient_UpdateUserExtensionResource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.UpdateUserExtensionResource(
 				context.TODO(), tt.userID, tt.extensionID, tt.erdID, tt.erdVersion,
@@ -843,7 +834,7 @@ func TestClient_UpdateUserExtensionResource(t *testing.T) {
 
 func TestClient_DeleteUserExtensionResource(t *testing.T) {
 	type fields struct {
-		httpClient *mockHTTPDoer
+		transport *mockTransport
 	}
 
 	tests := []struct {
@@ -865,7 +856,7 @@ func TestClient_DeleteUserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       []byte(testExtensionResourceResponse),
 					statusCode: http.StatusOK,
@@ -881,7 +872,7 @@ func TestClient_DeleteUserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -896,7 +887,7 @@ func TestClient_DeleteUserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -911,7 +902,7 @@ func TestClient_DeleteUserExtensionResource(t *testing.T) {
 			erdVersion: "v1alpha1",
 			resourceID: "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -925,7 +916,7 @@ func TestClient_DeleteUserExtensionResource(t *testing.T) {
 			extensionID: "test-extension-1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -940,7 +931,7 @@ func TestClient_DeleteUserExtensionResource(t *testing.T) {
 			erdID:       "erd-1",
 			erdVersion:  "v1alpha1",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -956,7 +947,7 @@ func TestClient_DeleteUserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"extension does not exist"}`),
@@ -973,7 +964,7 @@ func TestClient_DeleteUserExtensionResource(t *testing.T) {
 			erdVersion:  "v1alpha1",
 			resourceID:  "673ccd3a-1381-4e68-bc90-04e5f6745b9c",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusNotFound,
 					resp:       []byte(`{"error":"ERD does not exist"}`),
@@ -987,11 +978,9 @@ func TestClient_DeleteUserExtensionResource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			err := c.DeleteUserExtensionResource(context.TODO(), tt.userID, tt.extensionID, tt.erdID, tt.erdVersion, tt.resourceID)
 

--- a/pkg/client/users_test.go
+++ b/pkg/client/users_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2"
 
 	"github.com/metal-toolbox/governor-api/pkg/api/v1alpha1"
 	"github.com/metal-toolbox/governor-api/pkg/api/v1beta1"
@@ -25,7 +24,7 @@ func TestClient_Users(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -37,7 +36,7 @@ func TestClient_Users(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testUsersResponse,
 					statusCode: http.StatusOK,
@@ -48,7 +47,7 @@ func TestClient_Users(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -58,7 +57,7 @@ func TestClient_Users(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -70,11 +69,9 @@ func TestClient_Users(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.Users(context.TODO(), false)
 
@@ -100,7 +97,7 @@ func TestClient_UsersV2(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -112,7 +109,7 @@ func TestClient_UsersV2(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPMultiDoer{
+				transport: &mockMultiTransport{
 					t:          t,
 					resp:       testUsersResponseV2,
 					statusCode: http.StatusOK,
@@ -123,7 +120,7 @@ func TestClient_UsersV2(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -133,7 +130,7 @@ func TestClient_UsersV2(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -145,11 +142,9 @@ func TestClient_UsersV2(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.UsersV2(context.TODO(), map[string][]string{})
 
@@ -175,7 +170,7 @@ func TestClient_User(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -188,7 +183,7 @@ func TestClient_User(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testUserResponse,
 					statusCode: http.StatusOK,
@@ -200,7 +195,7 @@ func TestClient_User(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -211,7 +206,7 @@ func TestClient_User(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -223,7 +218,7 @@ func TestClient_User(t *testing.T) {
 		{
 			name: "missing id in request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -234,11 +229,9 @@ func TestClient_User(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.User(context.TODO(), tt.id, false)
 
@@ -264,7 +257,7 @@ func TestClient_CreateUser(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -277,7 +270,7 @@ func TestClient_CreateUser(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testUserResponse,
 					statusCode: http.StatusOK,
@@ -293,7 +286,7 @@ func TestClient_CreateUser(t *testing.T) {
 		{
 			name: "example request status accepted",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testUserResponse,
 					statusCode: http.StatusAccepted,
@@ -309,7 +302,7 @@ func TestClient_CreateUser(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -324,7 +317,7 @@ func TestClient_CreateUser(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -341,11 +334,9 @@ func TestClient_CreateUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.CreateUser(context.TODO(), tt.req)
 
@@ -362,7 +353,7 @@ func TestClient_CreateUser(t *testing.T) {
 
 func TestClient_DeleteUser(t *testing.T) {
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -374,7 +365,7 @@ func TestClient_DeleteUser(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testUserResponse,
 					statusCode: http.StatusOK,
@@ -385,7 +376,7 @@ func TestClient_DeleteUser(t *testing.T) {
 		{
 			name: "example request accepted",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testUserResponse,
 					statusCode: http.StatusAccepted,
@@ -396,7 +387,7 @@ func TestClient_DeleteUser(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -407,7 +398,7 @@ func TestClient_DeleteUser(t *testing.T) {
 		{
 			name: "missing id in request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -418,11 +409,9 @@ func TestClient_DeleteUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			err := c.DeleteUser(context.TODO(), tt.id)
 
@@ -447,7 +436,7 @@ func TestClient_UpdateUser(t *testing.T) {
 	}
 
 	type fields struct {
-		httpClient HTTPDoer
+		transport http.RoundTripper
 	}
 
 	tests := []struct {
@@ -461,7 +450,7 @@ func TestClient_UpdateUser(t *testing.T) {
 		{
 			name: "example request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testUserResponse,
 					statusCode: http.StatusOK,
@@ -476,7 +465,7 @@ func TestClient_UpdateUser(t *testing.T) {
 		{
 			name: "example request status accepted",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					resp:       testUserResponse,
 					statusCode: http.StatusAccepted,
@@ -491,7 +480,7 @@ func TestClient_UpdateUser(t *testing.T) {
 		{
 			name: "non-success",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusInternalServerError,
 				},
@@ -505,7 +494,7 @@ func TestClient_UpdateUser(t *testing.T) {
 		{
 			name: "bad json response",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 					resp:       []byte(`{`),
@@ -520,7 +509,7 @@ func TestClient_UpdateUser(t *testing.T) {
 		{
 			name: "missing user id",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -533,7 +522,7 @@ func TestClient_UpdateUser(t *testing.T) {
 		{
 			name: "missing request",
 			fields: fields{
-				httpClient: &mockHTTPDoer{
+				transport: &mockTransport{
 					t:          t,
 					statusCode: http.StatusOK,
 				},
@@ -545,11 +534,9 @@ func TestClient_UpdateUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				url:                    "https://the.gov/",
-				logger:                 zap.NewNop(),
-				httpClient:             tt.fields.httpClient,
-				clientCredentialConfig: &mockTokener{t: t},
-				token:                  &oauth2.Token{AccessToken: "topSekret"},
+				url:        "https://the.gov/",
+				logger:     zap.NewNop(),
+				httpClient: &http.Client{Transport: tt.fields.transport},
 			}
 			got, err := c.UpdateUser(context.TODO(), tt.id, tt.req)
 


### PR DESCRIPTION
## Summary
- Governor client now takes an `oauth2.TokenSource` (via `WithTokenSource`, or the deprecated `WithClientCredentialConfig`) and wires it into the `http.Client`'s `Transport` (`oauth2.Transport`), instead of manually fetching/refreshing a bearer token and injecting the header on every request.
- Collapses the `Client` struct's `c`/`httpClient` split into a single `httpClient *http.Client` field, dropping the now-dead `HTTPDoer`/`Tokener` interfaces.
- Test mocks moved from a client-level `Do()` stub (`mockHTTPDoer`) to transport-level `http.RoundTripper` mocks (`mockTransport`, `mockMultiTransport`), so tests exercise the real `http.Client` request path instead of standing in for it.

Prep work for rolling out workload identity federation across all governor clients.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/client/...`
- [x] `go test ./pkg/client/...` (all passing)